### PR TITLE
Browzine Service configurations (Issue #32)

### DIFF
--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -185,22 +185,51 @@ browzine.primo = (function() {
     var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png";
 
     if(isJournal(scope)) {
-      browzineWebLinkText = browzine.journalBrowZineWebLinkText || browzine.primoJournalBrowZineWebLinkText || "View Journal Contents";
+
+      if(typeof browzine.primoJournalBrowZineWebLinkText !== 'undefined') {
+
+        if(browzine.primoJournalBrowZineWebLinkText  === null || browzine.primoJournalBrowZineWebLinkText  === "") {
+          // Var purposely empty in Primo JS file, service NOT wanted so set to empty string 
+          browzineWebLinkText = "";
+        } else {
+          // Var exists in Primo JS file, CUSTOMIZED service wanted so set to var-string value
+          browzineWebLinkText = browzine.journalBrowZineWebLinkText || browzine.primoJournalBrowZineWebLinkText;
+        }
+      } else {
+        // Var not present in Primo JS file, DEFAULT service wanted so set to suggested string
+        browzineWebLinkText = "View Journal Contents";
+      }
     }
 
     if(isArticle(scope)) {
-      browzineWebLinkText = browzine.articleBrowZineWebLinkText || browzine.primoArticleBrowZineWebLinkText || "View Issue Contents";
+
+      if(typeof browzine.primoArticleBrowZineWebLinkText !== 'undefined') {
+
+        if(browzine.primoArticleBrowZineWebLinkText  === null || browzine.primoArticleBrowZineWebLinkText  === "") {
+          // Var purposely empty in Primo JS file, service NOT wanted so set to empty string  
+          browzineWebLinkText = "";
+        } else {
+          // Var exists in Primo JS file, CUSTOMIZED service wanted so set to var-string value
+          browzineWebLinkText = browzine.articleBrowZineWebLinkText || browzine.primoArticleBrowZineWebLinkText;
+        }
+      } else {
+        // Var not present in Primo JS file, DEFAULT service wanted so set to suggested string
+        browzineWebLinkText = "View Issue Contents";
+      }
     }
 
-    var template = "<div class='browzine'>" +
-                      "<a class='browzine-web-link' href='{browzineWebLink}' target='_blank' title='{browzineWebLinkText} in BrowZine'>" +
-                          "<img src='{bookIcon}' class='browzine-book-icon'/> {browzineWebLinkText}" +
-                      "</a>" +
-                   "</div>";
-
-    template = template.replace(/{browzineWebLink}/g, browzineWebLink);
-    template = template.replace(/{browzineWebLinkText}/g, browzineWebLinkText);
-    template = template.replace(/{bookIcon}/g, bookIcon);
+    var template = "<!-- Browzine web link is turned off. -->";
+    if(browzineWebLinkText !== "") {
+      template = "<div class='browzine'>" +
+                    "<a class='browzine-web-link' href='{browzineWebLink}' target='_blank' title='{browzineWebLinkText} in BrowZine'>" +
+                        "<img src='{bookIcon}' class='browzine-book-icon'/> {browzineWebLinkText}" +
+                    "</a>" +
+                 "</div>";
+   
+      template = template.replace(/{browzineWebLink}/g, browzineWebLink);
+      template = template.replace(/{browzineWebLinkText}/g, browzineWebLinkText);
+      template = template.replace(/{bookIcon}/g, bookIcon);
+    }
 
     return template;
   };

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -147,15 +147,21 @@ browzine.primo = (function() {
   function getCoverImageUrl(scope, data, journal) {
     var coverImageUrl = null;
 
-    if(isJournal(scope)) {
-      if(data && data.coverImageUrl) {
-        coverImageUrl = data.coverImageUrl;
-      }
-    }
+    if(typeof browzine.primoUseCoverImageBrowZineService !== 'undefined' && browzine.primoUseCoverImageBrowZineService === false) {
+        // Var exists in Primo JS file and is False, service NOT wanted so set to False.
+        coverImageUrl = false;
+    } else {
 
-    if(isArticle(scope)) {
-      if(journal && journal.coverImageUrl) {
-        coverImageUrl = journal.coverImageUrl;
+      if(isJournal(scope)) {
+        if(data && data.coverImageUrl) {
+          coverImageUrl = data.coverImageUrl;
+        }
+      }
+
+      if(isArticle(scope)) {
+        if(journal && journal.coverImageUrl) {
+          coverImageUrl = journal.coverImageUrl;
+        }
       }
     }
 


### PR DESCRIPTION
 Summary - Github Issue #32 

Changes to adapter to control use of each Browzine service (Article web link, Journal web link, Cover images)

## Description

Changes made to two functions to check for whether a variable exists in Primo _custom.js_ file or whether legacy variables are an empty string, either of which brings new behavior into play.


## Implementation Notes

Entry of the following variables into the Primo _config.js_ file:

```
    primoJournalBrowZineWebLinkText: "View Journal",
    primoArticleBrowZineWebLinkText: "",
    primoUseCoverImageBrowZineService: false,
```
Using the values above, the expected result is that **no** _cover images_ are shown and only the journals will show a web link, in this case it would be the "View Journal" string.

## Deploy Precautions

- None
