### PR TITLE
remove link title

### DIFF
--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -193,7 +193,7 @@ browzine.primo = (function() {
     }
 
     var template = "<div class='browzine' style='line-height: 1.4em;'>" +
-                      "<a class='browzine-web-link' href='{browzineWebLink}' target='_blank' title='{browzineWebLinkText} in BrowZine'>" +
+                      "<a class='browzine-web-link' href='{browzineWebLink}' target='_blank'>" +
                           "<img src='{bookIcon}' class='browzine-book-icon' style='margin-bottom: -1px; margin-right: 2.5px;' aria-hidden='true'/> " +
                           "<span class='browzine-web-link-text'>{browzineWebLinkText}</span> " +
                           "<md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon>" +


### PR DESCRIPTION
The link title attribute here is unnecessary since it pretty much repeats the link text, but the main reason for this pull request is that the link title in the current form interferes with the ability to translate the link text.
We've translated the `primoJournalBrowZineWebLinkText` in our custom.js to Swedish, which is then ruined by the "in Browzine" in the title which we cannot adjust unless we host this script ourselves.

## Summary - [BZ-XXXX](https://thirdiron.atlassian.net/browse/BZ-XXXX)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->



## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->



## Implementation Notes

<!-- Optional: Any file / API changes done to accomplish the larger goal laid out in the summary.-->

1. ​

## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- :warning: Depends on another PR getting into production first: 
- :warning: Another PR is waiting on this one to get merged:
- :warning: Has to be deployed concurrently with another system: 
- :warning: Potential to break other untested functionality in production:
- :warning: Other: 
- None
