### PR TITLE
feature/primo-cycle-until-journal-cover-element-appears-BZ-4786

### DIFF
--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -255,12 +255,14 @@ browzine.primo = (function() {
               var elementParent = getElementParent(element);
               var coverImages = elementParent.querySelectorAll("prm-search-result-thumbnail-container img");
 
-              if(coverImages[0].className.indexOf("fan-img") > -1) {
-                Array.prototype.forEach.call(coverImages, function(coverImage) {
-                  coverImage.src = coverImageUrl;
-                });
-              } else {
-                poll();
+              if(coverImages[0]) {
+                if(coverImages[0].className.indexOf("fan-img") > -1) {
+                  Array.prototype.forEach.call(coverImages, function(coverImage) {
+                    coverImage.src = coverImageUrl;
+                  });
+                } else {
+                  poll();
+                }
               }
             });
           })();

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -250,21 +250,19 @@ browzine.primo = (function() {
         }
 
         if(coverImageUrl && browzineEnabled) {
-          (function poll(){
-            setTimeout(function(){
-              var elementParent = getElementParent(element);
-              var coverImages = elementParent.querySelectorAll("prm-search-result-thumbnail-container img");
+          (function poll() {
+            var elementParent = getElementParent(element);
+            var coverImages = elementParent.querySelectorAll("prm-search-result-thumbnail-container img");
 
-              if(coverImages[0]) {
-                if(coverImages[0].className.indexOf("fan-img") > -1) {
-                  Array.prototype.forEach.call(coverImages, function(coverImage) {
-                    coverImage.src = coverImageUrl;
-                  });
-                } else {
-                  poll();
-                }
+            if(coverImages[0]) {
+              if(coverImages[0].className.indexOf("fan-img") > -1) {
+                Array.prototype.forEach.call(coverImages, function(coverImage) {
+                  coverImage.src = coverImageUrl;
+                });
+              } else {
+                requestAnimationFrame(poll);
               }
-            }, (1000 / 60));
+            }
           })();
         }
       }

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -264,7 +264,7 @@ browzine.primo = (function() {
                   poll();
                 }
               }
-            });
+            }, (1000 / 60));
           })();
         }
       }

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -247,21 +247,23 @@ browzine.primo = (function() {
         if(browzineWebLink && browzineEnabled) {
           var template = buildTemplate(scope, browzineWebLink);
           element.append(template);
-          $scope.$apply();
         }
 
         if(coverImageUrl && browzineEnabled) {
-          setTimeout(function() {
-            var elementParent = getElementParent(element);
-            var coverImages = elementParent.querySelectorAll("prm-search-result-thumbnail-container img");
+          (function poll(){
+            setTimeout(function(){
+              var elementParent = getElementParent(element);
+              var coverImages = elementParent.querySelectorAll("prm-search-result-thumbnail-container img");
 
-            Array.prototype.forEach.call(coverImages, function(coverImage) {
-              coverImage.src = coverImageUrl;
-              $scope.$apply();
+              if(coverImages[0].className.indexOf("fan-img") > -1) {
+                Array.prototype.forEach.call(coverImages, function(coverImage) {
+                  coverImage.src = coverImageUrl;
+                });
+              } else {
+                poll();
+              }
             });
-
-            $scope.$apply();
-          }, 1000);
+          })();
         }
       }
     };

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -82,7 +82,7 @@ describe("BrowZine Primo Adapter >", function() {
     });
 
     it("should have an enhanced browzine journal cover", function(done) {
-      setTimeout(function() {
+      requestAnimationFrame(function() {
         var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
 
         Array.prototype.forEach.call(coverImages, function(coverImage) {
@@ -90,7 +90,7 @@ describe("BrowZine Primo Adapter >", function() {
         });
 
         done();
-      }, (1000 / 60));
+      });
     });
   });
 
@@ -177,7 +177,7 @@ describe("BrowZine Primo Adapter >", function() {
     });
 
     it("should have an enhanced browzine journal cover", function(done) {
-      setTimeout(function() {
+      requestAnimationFrame(function() {
         var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
         expect(coverImages).toBeDefined();
 
@@ -186,7 +186,7 @@ describe("BrowZine Primo Adapter >", function() {
         });
 
         done();
-      }, (1000 / 60));
+      });
     });
   });
 

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -7,7 +7,7 @@ describe("BrowZine Primo Adapter >", function() {
     beforeEach(function() {
       primo = browzine.primo;
 
-      searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img src=''/><img src=''/><img src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+      searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line></prm-search-result-availability-line></div></prm-brief-result-container></div>");
 
       inject(function ($compile, $rootScope) {
         $scope = $rootScope.$new();
@@ -88,8 +88,9 @@ describe("BrowZine Primo Adapter >", function() {
         Array.prototype.forEach.call(coverImages, function(coverImage) {
           expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
         });
+
         done();
-      }, 1000);
+      });
     });
   });
 
@@ -97,7 +98,7 @@ describe("BrowZine Primo Adapter >", function() {
     beforeEach(function() {
       primo = browzine.primo;
 
-      searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+      searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line></prm-search-result-availability-line></div></prm-brief-result-container></div>");
 
       inject(function ($compile, $rootScope) {
         $scope = $rootScope.$new();
@@ -183,8 +184,9 @@ describe("BrowZine Primo Adapter >", function() {
         Array.prototype.forEach.call(coverImages, function(coverImage) {
           expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
         });
+
         done();
-      }, 1000);
+      });
     });
   });
 

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -90,7 +90,7 @@ describe("BrowZine Primo Adapter >", function() {
         });
 
         done();
-      });
+      }, (1000 / 60));
     });
   });
 
@@ -186,7 +186,7 @@ describe("BrowZine Primo Adapter >", function() {
         });
 
         done();
-      });
+      }, (1000 / 60));
     });
   });
 


### PR DESCRIPTION
## Summary - [BZ-4786](https://thirdiron.atlassian.net/browse/BZ-4786)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Primo: Polls for the Journal Cover Image element(s); Sets the Journal Cover Image element(s) once available.

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

Should be snappier overall. Should also work a lot better for internet connections that have lower bandwidth or higher latency issues.



## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None
