### PR TITLE
feature/direct-to-pdf-BZ-4508

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ As a Custom Script Url:
 
 Customize the naming conventions for each type of search result - Journal/Article - by changing the wording in the quotes below:
 
-e.g. You can customize "View the Journal", "View Complete Issue", "Browse Now". These customizations are optional and the defaults are shown below.
+e.g. You can customize "View the Journal", "View Complete Issue", "Browse Now" and whether to enable direct to PDF links. These customizations are optional and the defaults are shown below.
 
 ```
 var browzine = {
@@ -67,6 +67,9 @@ var browzine = {
   summonArticleWording: "View Complete Issue",
   summonJournalBrowZineWebLinkText: "Browse Now",
   summonArticleBrowZineWebLinkText: "Browse Now",
+  summonArticlePDFDownloadLinkEnabled: true,
+  summonArticlePDFDownloadWording: "Article PDF",
+  summonArticlePDFDownloadLinkText: "Download Now",
 };
 ```
 
@@ -123,8 +126,6 @@ Update the following code snippet with the `api` endpoint and `apiKey` values:
   window.browzine = {
     api: "https://public-api.thirdiron.com/public/v1/libraries/XXX",
     apiKey: "ENTER API KEY",
-    primoJournalBrowZineWebLinkText: "View Journal Contents",
-    primoArticleBrowZineWebLinkText: "View Issue Contents",
   };
 
   browzine.script = document.createElement("script");
@@ -162,6 +163,8 @@ window.browzine = {
   apiKey: "ENTER API KEY",
   primoJournalBrowZineWebLinkText: "View Journal Contents",
   primoArticleBrowZineWebLinkText: "View Issue Contents",
+  primoArticlePDFDownloadLinkEnabled: true,
+  primoArticlePDFDownloadLinkText: "Download PDF",
 };
 ```
 

--- a/src/360-core/browzine-360-core-adapter.js
+++ b/src/360-core/browzine-360-core-adapter.js
@@ -144,7 +144,7 @@ browzine.serSol360Core = (function() {
     return defaultCoverImage;
   };
 
-  function buildTemplate(browzineWebLink) {
+  function browzineWebLinkTemplate(browzineWebLink) {
     var browzineWebLinkText = "";
     var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png";
 
@@ -173,7 +173,7 @@ browzine.serSol360Core = (function() {
         var defaultCoverImage = isDefaultCoverImage(coverImageUrl);
 
         if(browzineWebLink) {
-          var template = buildTemplate(browzineWebLink);
+          var template = browzineWebLinkTemplate(browzineWebLink);
           $(title.target).find(".results-identifier").append(template);
         }
 
@@ -214,7 +214,7 @@ browzine.serSol360Core = (function() {
 
   return {
     adapter: adapter,
-    buildTemplate: buildTemplate,
+    browzineWebLinkTemplate: browzineWebLinkTemplate,
     getCoverImageUrl: getCoverImageUrl,
     getBrowZineWebLink: getBrowZineWebLink,
     getData: getData,

--- a/src/360-core/browzine-360-core-adapter.js
+++ b/src/360-core/browzine-360-core-adapter.js
@@ -134,6 +134,16 @@ browzine.serSol360Core = (function() {
     return browzineEnabled;
   };
 
+  function isDefaultCoverImage(coverImageUrl) {
+    var defaultCoverImage = false;
+
+    if(coverImageUrl && coverImageUrl.toLowerCase().indexOf("default") > -1) {
+      defaultCoverImage = true;
+    }
+
+    return defaultCoverImage;
+  };
+
   function buildTemplate(browzineWebLink) {
     var browzineWebLinkText = "";
     var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png";
@@ -160,14 +170,14 @@ browzine.serSol360Core = (function() {
         var data = getData(response);
         var browzineWebLink = getBrowZineWebLink(data);
         var coverImageUrl = getCoverImageUrl(data);
-        var browzineEnabled = getBrowZineEnabled(data);
+        var defaultCoverImage = isDefaultCoverImage(coverImageUrl);
 
         if(browzineWebLink) {
           var template = buildTemplate(browzineWebLink);
           $(title.target).find(".results-identifier").append(template);
         }
 
-        if(coverImageUrl && browzineEnabled) {
+        if(coverImageUrl && !defaultCoverImage) {
           var resultsTitleImageContainerSelector = ".results-title-image-div";
           var resultsTitleImageSelector = ".results-title-image-div img.results-title-image";
           var boxShadow = "1px 1px 2px #ccc";
@@ -217,6 +227,7 @@ browzine.serSol360Core = (function() {
     getTarget: getTarget,
     getIssn: getIssn,
     getBrowZineEnabled: getBrowZineEnabled,
+    isDefaultCoverImage: isDefaultCoverImage,
     searchTitles: searchTitles,
     urlRewrite: urlRewrite,
   };

--- a/src/360-core/browzine-360-core-adapter.js
+++ b/src/360-core/browzine-360-core-adapter.js
@@ -146,7 +146,7 @@ browzine.serSol360Core = (function() {
 
   function browzineWebLinkTemplate(browzineWebLink) {
     var browzineWebLinkText = "";
-    var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png";
+    var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png";
 
     browzineWebLinkText = browzine.serSol360CoreJournalBrowZineWebLinkText || "View Journal in BrowZine";
 

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -214,12 +214,12 @@ browzine.primo = (function() {
   };
 
   function directToPDFTemplate(directToPDFUrl) {
-    var pdfIcon = "https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png";
+    var pdfIcon = "https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine-pdf-download-icon.png";
     var articlePDFDownloadLinkText = browzine.primoArticlePDFDownloadLinkText || "Download Now";
 
-    var template = "<div class='browzine' style='line-height: 1.4em;'>" +
+    var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
                       "<a class='browzine-direct-to-pdf-link' href='{directToPDFUrl}' target='_blank'>" +
-                          "<img src='{pdfIcon}' class='browzine-pdf-icon' style='margin-bottom: -1px; margin-right: 2.5px;' aria-hidden='true'/> " +
+                          "<img src='{pdfIcon}' class='browzine-pdf-icon' style='margin-bottom: -3px; margin-right: 2.8px;' aria-hidden='true' width='13'/> " +
                           "<span class='browzine-web-link-text'>{articlePDFDownloadLinkText}</span> " +
                           "<md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon>" +
                       "</a>" +
@@ -234,7 +234,7 @@ browzine.primo = (function() {
 
   function browzineWebLinkTemplate(scope, browzineWebLink) {
     var browzineWebLinkText = "";
-    var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png";
+    var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png";
 
     if(isJournal(scope)) {
       browzineWebLinkText = browzine.journalBrowZineWebLinkText || browzine.primoJournalBrowZineWebLinkText || "View Journal Contents";
@@ -300,7 +300,17 @@ browzine.primo = (function() {
 
         if(directToPDFUrl && isArticle(scope) && showDirectToPDFLink()) {
           var template = directToPDFTemplate(directToPDFUrl);
-          element.prepend(template);
+
+          (function poll() {
+            var elementParent = getElementParent(element);
+            var availabilityLine = elementParent.querySelector("prm-search-result-availability-line .layout-align-start-start");
+
+            if(availabilityLine) {
+              availabilityLine.innerHTML = template + availabilityLine.innerHTML;
+            } else {
+              requestAnimationFrame(poll);
+            }
+          })();
         }
 
         if(browzineWebLink) {

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -213,7 +213,7 @@ browzine.primo = (function() {
     return enableShowDirectToPDFLink;
   };
 
-  function buildTemplate(scope, browzineWebLink) {
+  function browzineWebLinkTemplate(scope, browzineWebLink) {
     var browzineWebLinkText = "";
     var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png";
 
@@ -279,7 +279,7 @@ browzine.primo = (function() {
         var element = getElement(scope);
 
         if(browzineWebLink) {
-          var template = buildTemplate(scope, browzineWebLink);
+          var template = browzineWebLinkTemplate(scope, browzineWebLink);
           element.append(template);
         }
 
@@ -323,7 +323,7 @@ browzine.primo = (function() {
     isDefaultCoverImage: isDefaultCoverImage,
     getDirectToPDFUrl: getDirectToPDFUrl,
     showDirectToPDFLink: showDirectToPDFLink,
-    buildTemplate: buildTemplate,
+    browzineWebLinkTemplate: browzineWebLinkTemplate,
     getElement: getElement,
     getElementParent: getElementParent,
     getScope: getScope,

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -213,6 +213,25 @@ browzine.primo = (function() {
     return enableShowDirectToPDFLink;
   };
 
+  function directToPDFTemplate(directToPDFUrl) {
+    var pdfIcon = "https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png";
+    var articlePDFDownloadLinkText = browzine.primoArticlePDFDownloadLinkText || "Download Now";
+
+    var template = "<div class='browzine' style='line-height: 1.4em;'>" +
+                      "<a class='browzine-direct-to-pdf-link' href='{directToPDFUrl}' target='_blank'>" +
+                          "<img src='{pdfIcon}' class='browzine-pdf-icon' style='margin-bottom: -1px; margin-right: 2.5px;' aria-hidden='true'/> " +
+                          "<span class='browzine-web-link-text'>{articlePDFDownloadLinkText}</span> " +
+                          "<md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon>" +
+                      "</a>" +
+                   "</div>";
+
+    template = template.replace(/{directToPDFUrl}/g, directToPDFUrl);
+    template = template.replace(/{articlePDFDownloadLinkText}/g, articlePDFDownloadLinkText);
+    template = template.replace(/{pdfIcon}/g, pdfIcon);
+
+    return template;
+  };
+
   function browzineWebLinkTemplate(scope, browzineWebLink) {
     var browzineWebLinkText = "";
     var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png";
@@ -276,7 +295,13 @@ browzine.primo = (function() {
         var coverImageUrl = getCoverImageUrl(scope, data, journal);
         var defaultCoverImage = isDefaultCoverImage(coverImageUrl);
         var directToPDFUrl = getDirectToPDFUrl(scope, data);
+
         var element = getElement(scope);
+
+        if(directToPDFUrl && isArticle(scope) && showDirectToPDFLink()) {
+          var template = directToPDFTemplate(directToPDFUrl);
+          element.prepend(template);
+        }
 
         if(browzineWebLink) {
           var template = browzineWebLinkTemplate(scope, browzineWebLink);
@@ -323,6 +348,7 @@ browzine.primo = (function() {
     isDefaultCoverImage: isDefaultCoverImage,
     getDirectToPDFUrl: getDirectToPDFUrl,
     showDirectToPDFLink: showDirectToPDFLink,
+    directToPDFTemplate: directToPDFTemplate,
     browzineWebLinkTemplate: browzineWebLinkTemplate,
     getElement: getElement,
     getElementParent: getElementParent,

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -180,6 +180,16 @@ browzine.primo = (function() {
     return browzineEnabled;
   };
 
+  function isDefaultCoverImage(coverImageUrl) {
+    var defaultCoverImage = false;
+
+    if(coverImageUrl && coverImageUrl.toLowerCase().indexOf("default") > -1) {
+      defaultCoverImage = true;
+    }
+
+    return defaultCoverImage;
+  };
+
   function buildTemplate(scope, browzineWebLink) {
     var browzineWebLinkText = "";
     var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png";
@@ -241,15 +251,15 @@ browzine.primo = (function() {
 
         var browzineWebLink = getBrowZineWebLink(data);
         var coverImageUrl = getCoverImageUrl(scope, data, journal);
-        var browzineEnabled = getBrowZineEnabled(scope, data, journal);
+        var defaultCoverImage = isDefaultCoverImage(coverImageUrl);
         var element = getElement(scope);
 
-        if(browzineWebLink && browzineEnabled) {
+        if(browzineWebLink) {
           var template = buildTemplate(scope, browzineWebLink);
           element.append(template);
         }
 
-        if(coverImageUrl && browzineEnabled) {
+        if(coverImageUrl && !defaultCoverImage) {
           (function poll() {
             var elementParent = getElementParent(element);
             var coverImages = elementParent.querySelectorAll("prm-search-result-thumbnail-container img");
@@ -286,6 +296,7 @@ browzine.primo = (function() {
     getBrowZineWebLink: getBrowZineWebLink,
     getCoverImageUrl: getCoverImageUrl,
     getBrowZineEnabled: getBrowZineEnabled,
+    isDefaultCoverImage: isDefaultCoverImage,
     buildTemplate: buildTemplate,
     getElement: getElement,
     getElementParent: getElementParent,

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -190,6 +190,29 @@ browzine.primo = (function() {
     return defaultCoverImage;
   };
 
+  function getDirectToPDFUrl(scope, data) {
+    var directToPDFUrl = null;
+
+    if(isArticle(scope)) {
+      if(data.fullTextFile) {
+        directToPDFUrl = data.fullTextFile;
+      }
+    }
+
+    return directToPDFUrl;
+  };
+
+  function showDirectToPDFLink() {
+    var enableShowDirectToPDFLink = false;
+    var config = browzine.primoArticlePDFDownloadLinkEnabled;
+
+    if(typeof config === "undefined" || config === null || config === true) {
+      enableShowDirectToPDFLink = true;
+    }
+
+    return enableShowDirectToPDFLink;
+  };
+
   function buildTemplate(scope, browzineWebLink) {
     var browzineWebLinkText = "";
     var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png";
@@ -252,6 +275,7 @@ browzine.primo = (function() {
         var browzineWebLink = getBrowZineWebLink(data);
         var coverImageUrl = getCoverImageUrl(scope, data, journal);
         var defaultCoverImage = isDefaultCoverImage(coverImageUrl);
+        var directToPDFUrl = getDirectToPDFUrl(scope, data);
         var element = getElement(scope);
 
         if(browzineWebLink) {
@@ -297,6 +321,8 @@ browzine.primo = (function() {
     getCoverImageUrl: getCoverImageUrl,
     getBrowZineEnabled: getBrowZineEnabled,
     isDefaultCoverImage: isDefaultCoverImage,
+    getDirectToPDFUrl: getDirectToPDFUrl,
+    showDirectToPDFLink: showDirectToPDFLink,
     buildTemplate: buildTemplate,
     getElement: getElement,
     getElementParent: getElementParent,

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -183,14 +183,10 @@ browzine.summon = (function() {
     return enableShowDirectToPDFLink;
   };
 
-  function buildTemplate(scope, browzineWebLink, directToPDFUrl) {
+  function browzineWebLinkTemplate(scope, browzineWebLink) {
     var wording = "";
     var browzineWebLinkText = "";
     var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png";
-    var pdfIcon = "https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png";
-    var articlePDFDownloadWording = "";
-    var articlePDFDownloadLinkText = "";
-    var directToPDFTemplate = "";
 
     if(isJournal(scope)) {
       wording = browzine.journalWording || browzine.summonJournalWording || "View the Journal";
@@ -200,17 +196,9 @@ browzine.summon = (function() {
     if(isArticle(scope)) {
       wording = browzine.articleWording || browzine.summonArticleWording || "View Complete Issue";
       browzineWebLinkText = browzine.articleBrowZineWebLinkText || browzine.summonArticleBrowZineWebLinkText || "Browse Now";
-
-      articlePDFDownloadWording = browzine.summonArticlePDFDownloadWording || "Article PDF";
-      articlePDFDownloadLinkText = browzine.summonArticlePDFDownloadLinkText || "Download Now";
-
-      if(showDirectToPDFLink() && directToPDFUrl) {
-        directToPDFTemplate = "{articlePDFDownloadWording}: <a class='browzine-direct-to-pdf-link' href='{directToPDFUrl}' target='_blank' style='text-decoration: underline; color: #333;'>{articlePDFDownloadLinkText}</a> <img class='browzine-pdf-icon' src='{pdfIcon}'/> <br/>";
-      }
     }
 
     var template = "<div class='browzine'>" +
-                     "{directToPDFTemplate}" +
                      "{wording}: <a class='browzine-web-link' href='{browzineWebLink}' target='_blank' style='text-decoration: underline; color: #333;'>{browzineWebLinkText}</a> <img class='browzine-book-icon' src='{bookIcon}'/>" +
                    "</div>";
 
@@ -218,6 +206,22 @@ browzine.summon = (function() {
     template = template.replace(/{browzineWebLink}/g, browzineWebLink);
     template = template.replace(/{browzineWebLinkText}/g, browzineWebLinkText);
     template = template.replace(/{bookIcon}/g, bookIcon);
+
+    return template;
+  };
+
+  function directToPDFTemplate(directToPDFUrl) {
+    var pdfIcon = "https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png";
+    var articlePDFDownloadWording = "";
+    var articlePDFDownloadLinkText = "";
+    var directToPDFTemplate = "";
+
+    articlePDFDownloadWording = browzine.summonArticlePDFDownloadWording || "Article PDF";
+    articlePDFDownloadLinkText = browzine.summonArticlePDFDownloadLinkText || "Download Now";
+
+    var template = "<div class='browzine'>" +
+                     "{articlePDFDownloadWording}: <a class='browzine-direct-to-pdf-link' href='{directToPDFUrl}' target='_blank' style='text-decoration: underline; color: #333;'>{articlePDFDownloadLinkText}</a> <img class='browzine-pdf-icon' src='{pdfIcon}'/>" +
+                   "</div>";
 
     template = template.replace(/{directToPDFTemplate}/g, directToPDFTemplate);
     template = template.replace(/{articlePDFDownloadWording}/g, articlePDFDownloadWording);
@@ -250,8 +254,13 @@ browzine.summon = (function() {
       var defaultCoverImage = isDefaultCoverImage(coverImageUrl);
       var directToPDFUrl = getDirectToPDFUrl(scope, data);
 
+      if(directToPDFUrl && isArticle(scope) && showDirectToPDFLink()) {
+        var template = directToPDFTemplate(directToPDFUrl);
+        $(documentSummary).find(".docFooter .row:eq(0)").prepend(template);
+      }
+
       if(browzineWebLink) {
-        var template = buildTemplate(scope, browzineWebLink, directToPDFUrl);
+        var template = browzineWebLinkTemplate(scope, browzineWebLink);
         $(documentSummary).find(".docFooter .row:eq(0)").append(template);
       }
 
@@ -274,7 +283,8 @@ browzine.summon = (function() {
     isDefaultCoverImage: isDefaultCoverImage,
     getDirectToPDFUrl: getDirectToPDFUrl,
     showDirectToPDFLink: showDirectToPDFLink,
-    buildTemplate: buildTemplate,
+    browzineWebLinkTemplate: browzineWebLinkTemplate,
+    directToPDFTemplate: directToPDFTemplate,
     urlRewrite: urlRewrite,
   };
 }());

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -160,6 +160,29 @@ browzine.summon = (function() {
     return defaultCoverImage;
   };
 
+  function getDirectToPDFUrl(scope, data) {
+    var directToPDFUrl = null;
+
+    if(isArticle(scope)) {
+      if(data.fullTextFile) {
+        directToPDFUrl = data.fullTextFile;
+      }
+    }
+
+    return directToPDFUrl;
+  };
+
+  function showDirectToPDFLink() {
+    var enableShowDirectToPDFLink = false;
+    var config = browzine.summonArticlePDFDownloadLinkEnabled;
+
+    if(typeof config === "undefined" || config === null || config === true) {
+      enableShowDirectToPDFLink = true;
+    }
+
+    return enableShowDirectToPDFLink;
+  };
+
   function buildTemplate(scope, browzineWebLink) {
     var wording = "";
     var browzineWebLinkText = "";
@@ -208,6 +231,7 @@ browzine.summon = (function() {
       var browzineWebLink = getBrowZineWebLink(data);
       var coverImageUrl = getCoverImageUrl(scope, data, journal);
       var defaultCoverImage = isDefaultCoverImage(coverImageUrl);
+      var directToPDFUrl = getDirectToPDFUrl(scope, data);
 
       if(browzineWebLink) {
         var template = buildTemplate(scope, browzineWebLink);
@@ -231,6 +255,8 @@ browzine.summon = (function() {
     getCoverImageUrl: getCoverImageUrl,
     getBrowZineEnabled: getBrowZineEnabled,
     isDefaultCoverImage: isDefaultCoverImage,
+    getDirectToPDFUrl: getDirectToPDFUrl,
+    showDirectToPDFLink: showDirectToPDFLink,
     buildTemplate: buildTemplate,
     urlRewrite: urlRewrite,
   };

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -183,6 +183,23 @@ browzine.summon = (function() {
     return enableShowDirectToPDFLink;
   };
 
+  function directToPDFTemplate(directToPDFUrl) {
+    var pdfIcon = "https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png";
+    var articlePDFDownloadWording = browzine.summonArticlePDFDownloadWording || "Article PDF";
+    var articlePDFDownloadLinkText = browzine.summonArticlePDFDownloadLinkText || "Download Now";
+
+    var template = "<div class='browzine'>" +
+                     "{articlePDFDownloadWording}: <a class='browzine-direct-to-pdf-link' href='{directToPDFUrl}' target='_blank' style='text-decoration: underline; color: #333;'>{articlePDFDownloadLinkText}</a> <img class='browzine-pdf-icon' src='{pdfIcon}'/>" +
+                   "</div>";
+
+    template = template.replace(/{articlePDFDownloadWording}/g, articlePDFDownloadWording);
+    template = template.replace(/{directToPDFUrl}/g, directToPDFUrl);
+    template = template.replace(/{articlePDFDownloadLinkText}/g, articlePDFDownloadLinkText);
+    template = template.replace(/{pdfIcon}/g, pdfIcon);
+
+    return template;
+  };
+
   function browzineWebLinkTemplate(scope, browzineWebLink) {
     var wording = "";
     var browzineWebLinkText = "";
@@ -206,28 +223,6 @@ browzine.summon = (function() {
     template = template.replace(/{browzineWebLink}/g, browzineWebLink);
     template = template.replace(/{browzineWebLinkText}/g, browzineWebLinkText);
     template = template.replace(/{bookIcon}/g, bookIcon);
-
-    return template;
-  };
-
-  function directToPDFTemplate(directToPDFUrl) {
-    var pdfIcon = "https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png";
-    var articlePDFDownloadWording = "";
-    var articlePDFDownloadLinkText = "";
-    var directToPDFTemplate = "";
-
-    articlePDFDownloadWording = browzine.summonArticlePDFDownloadWording || "Article PDF";
-    articlePDFDownloadLinkText = browzine.summonArticlePDFDownloadLinkText || "Download Now";
-
-    var template = "<div class='browzine'>" +
-                     "{articlePDFDownloadWording}: <a class='browzine-direct-to-pdf-link' href='{directToPDFUrl}' target='_blank' style='text-decoration: underline; color: #333;'>{articlePDFDownloadLinkText}</a> <img class='browzine-pdf-icon' src='{pdfIcon}'/>" +
-                   "</div>";
-
-    template = template.replace(/{directToPDFTemplate}/g, directToPDFTemplate);
-    template = template.replace(/{articlePDFDownloadWording}/g, articlePDFDownloadWording);
-    template = template.replace(/{directToPDFUrl}/g, directToPDFUrl);
-    template = template.replace(/{articlePDFDownloadLinkText}/g, articlePDFDownloadLinkText);
-    template = template.replace(/{pdfIcon}/g, pdfIcon);
 
     return template;
   };

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -184,12 +184,12 @@ browzine.summon = (function() {
   };
 
   function directToPDFTemplate(directToPDFUrl) {
-    var pdfIcon = "https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png";
+    var pdfIcon = "https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine-pdf-download-icon.png";
     var articlePDFDownloadWording = browzine.summonArticlePDFDownloadWording || "Article PDF";
     var articlePDFDownloadLinkText = browzine.summonArticlePDFDownloadLinkText || "Download Now";
 
     var template = "<div class='browzine'>" +
-                     "{articlePDFDownloadWording}: <a class='browzine-direct-to-pdf-link' href='{directToPDFUrl}' target='_blank' style='text-decoration: underline; color: #333;'>{articlePDFDownloadLinkText}</a> <img class='browzine-pdf-icon' src='{pdfIcon}'/>" +
+                     "{articlePDFDownloadWording}: <a class='browzine-direct-to-pdf-link' href='{directToPDFUrl}' target='_blank' style='text-decoration: underline; color: #333;'>{articlePDFDownloadLinkText}</a> <img class='browzine-pdf-icon' src='{pdfIcon}' width='12'/>" +
                    "</div>";
 
     template = template.replace(/{articlePDFDownloadWording}/g, articlePDFDownloadWording);
@@ -203,7 +203,7 @@ browzine.summon = (function() {
   function browzineWebLinkTemplate(scope, browzineWebLink) {
     var wording = "";
     var browzineWebLinkText = "";
-    var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png";
+    var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png";
 
     if(isJournal(scope)) {
       wording = browzine.journalWording || browzine.summonJournalWording || "View the Journal";

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -183,10 +183,14 @@ browzine.summon = (function() {
     return enableShowDirectToPDFLink;
   };
 
-  function buildTemplate(scope, browzineWebLink) {
+  function buildTemplate(scope, browzineWebLink, directToPDFUrl) {
     var wording = "";
     var browzineWebLinkText = "";
     var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png";
+    var pdfIcon = "https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png";
+    var articlePDFDownloadWording = "";
+    var articlePDFDownloadLinkText = "";
+    var directToPDFTemplate = "";
 
     if(isJournal(scope)) {
       wording = browzine.journalWording || browzine.summonJournalWording || "View the Journal";
@@ -196,17 +200,30 @@ browzine.summon = (function() {
     if(isArticle(scope)) {
       wording = browzine.articleWording || browzine.summonArticleWording || "View Complete Issue";
       browzineWebLinkText = browzine.articleBrowZineWebLinkText || browzine.summonArticleBrowZineWebLinkText || "Browse Now";
+
+      articlePDFDownloadWording = browzine.summonArticlePDFDownloadWording || "Article PDF";
+      articlePDFDownloadLinkText = browzine.summonArticlePDFDownloadLinkText || "Download Now";
+
+      if(showDirectToPDFLink() && directToPDFUrl) {
+        directToPDFTemplate = "{articlePDFDownloadWording}: <a class='browzine-direct-to-pdf-link' href='{directToPDFUrl}' target='_blank' style='text-decoration: underline; color: #333;'>{articlePDFDownloadLinkText}</a> <img class='browzine-pdf-icon' src='{pdfIcon}'/> <br/>";
+      }
     }
 
     var template = "<div class='browzine'>" +
-                     "{wording}: <a class='browzine-web-link' href='{browzineWebLink}' target='_blank' style='text-decoration: underline; color: #333;'>{browzineWebLinkText}</a> " +
-                     "<img class='browzine-book-icon' src='{bookIcon}'/>" +
+                     "{directToPDFTemplate}" +
+                     "{wording}: <a class='browzine-web-link' href='{browzineWebLink}' target='_blank' style='text-decoration: underline; color: #333;'>{browzineWebLinkText}</a> <img class='browzine-book-icon' src='{bookIcon}'/>" +
                    "</div>";
 
     template = template.replace(/{wording}/g, wording);
     template = template.replace(/{browzineWebLink}/g, browzineWebLink);
     template = template.replace(/{browzineWebLinkText}/g, browzineWebLinkText);
     template = template.replace(/{bookIcon}/g, bookIcon);
+
+    template = template.replace(/{directToPDFTemplate}/g, directToPDFTemplate);
+    template = template.replace(/{articlePDFDownloadWording}/g, articlePDFDownloadWording);
+    template = template.replace(/{directToPDFUrl}/g, directToPDFUrl);
+    template = template.replace(/{articlePDFDownloadLinkText}/g, articlePDFDownloadLinkText);
+    template = template.replace(/{pdfIcon}/g, pdfIcon);
 
     return template;
   };
@@ -234,7 +251,7 @@ browzine.summon = (function() {
       var directToPDFUrl = getDirectToPDFUrl(scope, data);
 
       if(browzineWebLink) {
-        var template = buildTemplate(scope, browzineWebLink);
+        var template = buildTemplate(scope, browzineWebLink, directToPDFUrl);
         $(documentSummary).find(".docFooter .row:eq(0)").append(template);
       }
 

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -150,6 +150,16 @@ browzine.summon = (function() {
     return browzineEnabled;
   };
 
+  function isDefaultCoverImage(coverImageUrl) {
+    var defaultCoverImage = false;
+
+    if(coverImageUrl && coverImageUrl.toLowerCase().indexOf("default") > -1) {
+      defaultCoverImage = true;
+    }
+
+    return defaultCoverImage;
+  };
+
   function buildTemplate(scope, browzineWebLink) {
     var wording = "";
     var browzineWebLinkText = "";
@@ -197,14 +207,14 @@ browzine.summon = (function() {
 
       var browzineWebLink = getBrowZineWebLink(data);
       var coverImageUrl = getCoverImageUrl(scope, data, journal);
-      var browzineEnabled = getBrowZineEnabled(scope, data, journal);
+      var defaultCoverImage = isDefaultCoverImage(coverImageUrl);
 
       if(browzineWebLink) {
         var template = buildTemplate(scope, browzineWebLink);
         $(documentSummary).find(".docFooter .row:eq(0)").append(template);
       }
 
-      if(coverImageUrl && browzineEnabled) {
+      if(coverImageUrl && !defaultCoverImage) {
         $(documentSummary).find(".coverImage img").attr("src", coverImageUrl).attr("ng-src", coverImageUrl).css("box-shadow", "1px 1px 2px #ccc");
       }
     });
@@ -220,6 +230,7 @@ browzine.summon = (function() {
     getBrowZineWebLink: getBrowZineWebLink,
     getCoverImageUrl: getCoverImageUrl,
     getBrowZineEnabled: getBrowZineEnabled,
+    isDefaultCoverImage: isDefaultCoverImage,
     buildTemplate: buildTemplate,
     urlRewrite: urlRewrite,
   };

--- a/tests/acceptance/browzine-360-core-adapter-test.js
+++ b/tests/acceptance/browzine-360-core-adapter-test.js
@@ -54,7 +54,7 @@ describe("BrowZine SerSol 360 Core Adapter >", function() {
       expect(template.text().trim()).toEqual("View Journal in BrowZine");
       expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/10292");
       expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
-      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
     });
 
     it("should have an enhanced browzine journal cover", function() {

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -78,7 +78,7 @@ describe("BrowZine Primo Adapter >", function() {
       expect(template.text().trim()).toEqual("View Journal Contents");
       expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/10292");
       expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
-      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
     });
 
     it("should have an enhanced browzine journal cover", function(done) {
@@ -98,7 +98,7 @@ describe("BrowZine Primo Adapter >", function() {
     beforeEach(function() {
       primo = browzine.primo;
 
-      searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+      searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
 
       inject(function ($compile, $rootScope) {
         $scope = $rootScope.$new();
@@ -178,11 +178,11 @@ describe("BrowZine Primo Adapter >", function() {
 
       expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
       expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
-      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
 
       expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
       expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
-      expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png");
+      expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine-pdf-download-icon.png");
     });
 
     it("should have an enhanced browzine journal cover", function(done) {

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -170,11 +170,19 @@ describe("BrowZine Primo Adapter >", function() {
 
     it("should have an enhanced browse article in browzine option", function() {
       var template = searchResult.find(".browzine");
+
       expect(template).toBeDefined();
-      expect(template.text().trim()).toEqual("View Issue Contents");
+
+      expect(template.text().trim()).toContain("View Issue Contents");
+      expect(template.text().trim()).toContain("Download Now");
+
       expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
       expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
       expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+
+      expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
+      expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+      expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png");
     });
 
     it("should have an enhanced browzine journal cover", function(done) {

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -95,106 +95,210 @@ describe("BrowZine Primo Adapter >", function() {
   });
 
   describe("search results article >", function() {
-    beforeEach(function() {
-      primo = browzine.primo;
+    describe("search results article with both browzine web link and direct to pdf link >", function() {
+      beforeEach(function() {
+        primo = browzine.primo;
 
-      searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
 
-      inject(function ($compile, $rootScope) {
-        $scope = $rootScope.$new();
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
 
-        $scope.$ctrl = {
-          parentCtrl: {
-            result: {
-              pnx: {
-                display: {
-                  type: ["article"]
-                },
+          $scope.$ctrl = {
+            parentCtrl: {
+              result: {
+                pnx: {
+                  display: {
+                    type: ["article"]
+                  },
 
-                addata: {
-                  issn: ["0028-4793"],
-                  doi: ["10.1136/bmj.h2575"]
+                  addata: {
+                    issn: ["0028-4793"],
+                    doi: ["10.1136/bmj.h2575"]
+                  }
                 }
               }
             }
-          }
-        };
+          };
 
-        searchResult = $compile(searchResult)($scope);
-      });
-
-      $scope.$ctrl.parentCtrl.$element = searchResult;
-
-      jasmine.Ajax.install();
-
-      primo.searchResult($scope);
-
-      var request = jasmine.Ajax.requests.mostRecent();
-      request.respondWith({
-        status: 200,
-        contentType: "application/json",
-        response: JSON.stringify({
-          "data": {
-            "id": 55134408,
-            "type": "articles",
-            "title": "New England Journal of Medicine reconsiders relationship with industry",
-            "date": "2015-05-12",
-            "authors": "McCarthy, M.",
-            "inPress": false,
-            "availableThroughBrowzine": true,
-            "startPage": "h2575",
-            "endPage": "h2575",
-            "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575",
-            "fullTextFile": "https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file"
-          },
-          "included": [{
-            "id": 18126,
-            "type": "journals",
-            "title": "theBMJ",
-            "issn": "09598138",
-            "sjrValue": 2.567,
-            "coverImageUrl": "https://assets.thirdiron.com/images/covers/0959-8138.png",
-            "browzineEnabled": true,
-            "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
-          }]
-        })
-      });
-
-      expect(request.url).toMatch(/articles\/doi\/10.1136%2Fbmj.h2575/);
-      expect(request.method).toBe('GET');
-    });
-
-    afterEach(function() {
-      jasmine.Ajax.uninstall();
-    });
-
-    it("should have an enhanced browse article in browzine option", function() {
-      var template = searchResult.find(".browzine");
-
-      expect(template).toBeDefined();
-
-      expect(template.text().trim()).toContain("View Issue Contents");
-      expect(template.text().trim()).toContain("Download Now");
-
-      expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
-      expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
-      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
-
-      expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
-      expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
-      expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine-pdf-download-icon.png");
-    });
-
-    it("should have an enhanced browzine journal cover", function(done) {
-      requestAnimationFrame(function() {
-        var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
-        expect(coverImages).toBeDefined();
-
-        Array.prototype.forEach.call(coverImages, function(coverImage) {
-          expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
+          searchResult = $compile(searchResult)($scope);
         });
 
-        done();
+        $scope.$ctrl.parentCtrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 55134408,
+              "type": "articles",
+              "title": "New England Journal of Medicine reconsiders relationship with industry",
+              "date": "2015-05-12",
+              "authors": "McCarthy, M.",
+              "inPress": false,
+              "availableThroughBrowzine": true,
+              "startPage": "h2575",
+              "endPage": "h2575",
+              "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575",
+              "fullTextFile": "https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file"
+            },
+            "included": [{
+              "id": 18126,
+              "type": "journals",
+              "title": "theBMJ",
+              "issn": "09598138",
+              "sjrValue": 2.567,
+              "coverImageUrl": "https://assets.thirdiron.com/images/covers/0959-8138.png",
+              "browzineEnabled": true,
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
+            }]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1136%2Fbmj.h2575/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should have an enhanced browse article in browzine option", function() {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).toContain("Download Now");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
+
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine-pdf-download-icon.png");
+      });
+
+      it("should have an enhanced browzine journal cover", function(done) {
+        requestAnimationFrame(function() {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function(coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
+          });
+
+          done();
+        });
+      });
+    });
+
+    describe("search results article with browzine web link and disabled direct to pdf link >", function() {
+      beforeEach(function() {
+        primo = browzine.primo;
+        browzine.primoArticlePDFDownloadLinkEnabled = false;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.$ctrl = {
+            parentCtrl: {
+              result: {
+                pnx: {
+                  display: {
+                    type: ["article"]
+                  },
+
+                  addata: {
+                    issn: ["0028-4793"],
+                    doi: ["10.1136/bmj.h2575"]
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$ctrl.parentCtrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 55134408,
+              "type": "articles",
+              "title": "New England Journal of Medicine reconsiders relationship with industry",
+              "date": "2015-05-12",
+              "authors": "McCarthy, M.",
+              "inPress": false,
+              "availableThroughBrowzine": true,
+              "startPage": "h2575",
+              "endPage": "h2575",
+              "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575",
+              "fullTextFile": "https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file"
+            },
+            "included": [{
+              "id": 18126,
+              "type": "journals",
+              "title": "theBMJ",
+              "issn": "09598138",
+              "sjrValue": 2.567,
+              "coverImageUrl": "https://assets.thirdiron.com/images/covers/0959-8138.png",
+              "browzineEnabled": true,
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
+            }]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1136%2Fbmj.h2575/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+        delete browzine.primoArticlePDFDownloadLinkEnabled;
+      });
+
+      it("should have an enhanced browse article in browzine option", function() {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
+      });
+
+      it("should have an enhanced browzine journal cover", function(done) {
+        requestAnimationFrame(function() {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function(coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
+          });
+
+          done();
+        });
       });
     });
   });

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -144,7 +144,8 @@ describe("BrowZine Primo Adapter >", function() {
             "availableThroughBrowzine": true,
             "startPage": "h2575",
             "endPage": "h2575",
-            "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575"
+            "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575",
+            "fullTextFile": "https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file"
           },
           "included": [{
             "id": 18126,

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -116,11 +116,19 @@ describe("BrowZine Summon Adapter >", function() {
 
     it("should have an enhanced browse article in browzine option", function() {
       var template = documentSummary.find(".browzine");
+
       expect(template).toBeDefined();
-      expect(template.text().trim()).toEqual("View Complete Issue: Browse Now");
+
+      expect(template.text().trim()).toContain("View Complete Issue: Browse Now");
+      expect(template.text().trim()).toContain("Article PDF: Download Now");
+
       expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
       expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
       expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+
+      expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
+      expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+      expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png");
     });
 
     it("should have an enhanced browzine journal cover", function() {

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -91,7 +91,8 @@ describe("BrowZine Summon Adapter >", function() {
             "availableThroughBrowzine": true,
             "startPage": "h2575",
             "endPage": "h2575",
-            "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575"
+            "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575",
+            "fullTextFile": "https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file"
           },
           "included": [{
             "id": 18126,

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -50,7 +50,7 @@ describe("BrowZine Summon Adapter >", function() {
       expect(template.text().trim()).toEqual("View the Journal: Browse Now");
       expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/10292");
       expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
-      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
     });
 
     it("should have an enhanced browzine journal cover", function() {
@@ -124,11 +124,11 @@ describe("BrowZine Summon Adapter >", function() {
 
       expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
       expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
-      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
 
       expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
       expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
-      expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png");
+      expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine-pdf-download-icon.png");
     });
 
     it("should have an enhanced browzine journal cover", function() {

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -61,138 +61,214 @@ describe("BrowZine Summon Adapter >", function() {
   });
 
   describe("search results article >", function() {
-    beforeEach(function() {
-      summon = browzine.summon;
+    describe("search results article with both browzine web link and direct to pdf link >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
 
-      documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
 
-      inject(function ($compile, $rootScope) {
-        $scope = $rootScope.$new();
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
 
-        $scope.document = {
-          content_type: "Journal Article",
-          dois: ["10.1136/bmj.h2575"]
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1136/bmj.h2575"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        $.getJSON = function(endpoint, callback) {
+          expect(endpoint).toMatch(/articles\/doi\/10.1136%2Fbmj.h2575/);
+
+          return callback({
+            "data": {
+              "id": 55134408,
+              "type": "articles",
+              "title": "New England Journal of Medicine reconsiders relationship with industry",
+              "date": "2015-05-12",
+              "authors": "McCarthy, M.",
+              "inPress": false,
+              "availableThroughBrowzine": true,
+              "startPage": "h2575",
+              "endPage": "h2575",
+              "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575",
+              "fullTextFile": "https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file"
+            },
+            "included": [{
+              "id": 18126,
+              "type": "journals",
+              "title": "theBMJ",
+              "issn": "09598138",
+              "sjrValue": 2.567,
+              "coverImageUrl": "https://assets.thirdiron.com/images/covers/0959-8138.png",
+              "browzineEnabled": true,
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
+            }]
+          });
         };
 
-        documentSummary = $compile(documentSummary)($scope);
+        summon.adapter(documentSummary);
       });
 
-      $.getJSON = function(endpoint, callback) {
-        expect(endpoint).toMatch(/articles\/doi\/10.1136%2Fbmj.h2575/);
+      afterEach(function() {
 
-        return callback({
-          "data": {
-            "id": 55134408,
-            "type": "articles",
-            "title": "New England Journal of Medicine reconsiders relationship with industry",
-            "date": "2015-05-12",
-            "authors": "McCarthy, M.",
-            "inPress": false,
-            "availableThroughBrowzine": true,
-            "startPage": "h2575",
-            "endPage": "h2575",
-            "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575",
-            "fullTextFile": "https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file"
-          },
-          "included": [{
-            "id": 18126,
-            "type": "journals",
-            "title": "theBMJ",
-            "issn": "09598138",
-            "sjrValue": 2.567,
-            "coverImageUrl": "https://assets.thirdiron.com/images/covers/0959-8138.png",
-            "browzineEnabled": true,
-            "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
-          }]
+      });
+
+      it("should have an enhanced browse article in browzine option", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Complete Issue: Browse Now");
+        expect(template.text().trim()).toContain("Article PDF: Download Now");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
+
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine-pdf-download-icon.png");
+      });
+
+      it("should have an enhanced browzine journal cover", function() {
+        var coverImage = documentSummary.find(".coverImage img");
+        expect(coverImage).toBeDefined();
+        expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
+      });
+    });
+
+    describe("search results article with browzine web link and disabled direct to pdf link >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+        browzine.summonArticlePDFDownloadLinkEnabled = false;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1136/bmj.h2575"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
         });
-      };
 
-      summon.adapter(documentSummary);
-    });
+        $.getJSON = function(endpoint, callback) {
+          expect(endpoint).toMatch(/articles\/doi\/10.1136%2Fbmj.h2575/);
 
-    afterEach(function() {
-
-    });
-
-    it("should have an enhanced browse article in browzine option", function() {
-      var template = documentSummary.find(".browzine");
-
-      expect(template).toBeDefined();
-
-      expect(template.text().trim()).toContain("View Complete Issue: Browse Now");
-      expect(template.text().trim()).toContain("Article PDF: Download Now");
-
-      expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
-      expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
-      expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
-
-      expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
-      expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
-      expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine-pdf-download-icon.png");
-    });
-
-    it("should have an enhanced browzine journal cover", function() {
-      var coverImage = documentSummary.find(".coverImage img");
-      expect(coverImage).toBeDefined();
-      expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
-    });
-  });
-
-  describe("search results article with no browzineWebLink >", function() {
-    beforeEach(function() {
-      summon = browzine.summon;
-
-      documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
-
-      inject(function ($compile, $rootScope) {
-        $scope = $rootScope.$new();
-
-        $scope.document = {
-          content_type: "Journal Article",
-          dois: ["02.2016/bmj.h0830"]
+          return callback({
+            "data": {
+              "id": 55134408,
+              "type": "articles",
+              "title": "New England Journal of Medicine reconsiders relationship with industry",
+              "date": "2015-05-12",
+              "authors": "McCarthy, M.",
+              "inPress": false,
+              "availableThroughBrowzine": true,
+              "startPage": "h2575",
+              "endPage": "h2575",
+              "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575",
+              "fullTextFile": "https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file"
+            },
+            "included": [{
+              "id": 18126,
+              "type": "journals",
+              "title": "theBMJ",
+              "issn": "09598138",
+              "sjrValue": 2.567,
+              "coverImageUrl": "https://assets.thirdiron.com/images/covers/0959-8138.png",
+              "browzineEnabled": true,
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
+            }]
+          });
         };
 
-        documentSummary = $compile(documentSummary)($scope);
+        summon.adapter(documentSummary);
       });
 
-      $.getJSON = function(endpoint, callback) {
-        expect(endpoint).toMatch(/articles\/doi\/02.2016%2Fbmj.h0830/);
+      afterEach(function() {
+        delete browzine.summonArticlePDFDownloadLinkEnabled;
+      });
 
-        return callback({
-          "data": {
-            "id": 55134408,
-            "type": "articles",
-            "title": "Adefovir Dipivoxil for the Treatment of Hepatitis B e Antigen–Negative Chronic Hepatitis B",
-            "date": "2015-05-12",
-            "authors": "McCarthy, M.",
-            "inPress": false,
-            "availableThroughBrowzine": true,
-            "startPage": "h2575",
-            "endPage": "h2575"
-          },
-          "included": [{
-            "id": 18126,
-            "type": "journals",
-            "title": "theBMJ",
-            "issn": "09598138",
-            "sjrValue": 2.567,
-            "coverImageUrl": "https://assets.thirdiron.com/images/covers/0959-8138.png",
-            "browzineEnabled": true,
-            "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
-          }]
+      it("should have an enhanced browse article in browzine option", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Complete Issue: Browse Now");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
+      });
+
+      it("should have an enhanced browzine journal cover", function() {
+        var coverImage = documentSummary.find(".coverImage img");
+        expect(coverImage).toBeDefined();
+        expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
+      });
+    });
+
+    describe("search results article with no browzineWebLink >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["02.2016/bmj.h0830"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
         });
-      };
 
-      summon.adapter(documentSummary);
-    });
+        $.getJSON = function(endpoint, callback) {
+          expect(endpoint).toMatch(/articles\/doi\/02.2016%2Fbmj.h0830/);
 
-    afterEach(function() {
+          return callback({
+            "data": {
+              "id": 55134408,
+              "type": "articles",
+              "title": "Adefovir Dipivoxil for the Treatment of Hepatitis B e Antigen–Negative Chronic Hepatitis B",
+              "date": "2015-05-12",
+              "authors": "McCarthy, M.",
+              "inPress": false,
+              "availableThroughBrowzine": true,
+              "startPage": "h2575",
+              "endPage": "h2575"
+            },
+            "included": [{
+              "id": 18126,
+              "type": "journals",
+              "title": "theBMJ",
+              "issn": "09598138",
+              "sjrValue": 2.567,
+              "coverImageUrl": "https://assets.thirdiron.com/images/covers/0959-8138.png",
+              "browzineEnabled": true,
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
+            }]
+          });
+        };
 
-    });
+        summon.adapter(documentSummary);
+      });
 
-    it("should not have an enhanced browse article in browzine option", function() {
-      var template = documentSummary.find(".browzine");
-      expect(template.text().trim()).toEqual("");
+      afterEach(function() {
+
+      });
+
+      it("should not have an enhanced browse article in browzine option", function() {
+        var template = documentSummary.find(".browzine");
+        expect(template.text().trim()).toEqual("");
+      });
     });
   });
 });

--- a/tests/unit/models/360-core.js
+++ b/tests/unit/models/360-core.js
@@ -356,11 +356,11 @@ describe("SerSol 360 Core Model >", function() {
     });
   });
 
-  describe("serSol360Core model buildTemplate method >", function() {
+  describe("serSol360Core model browzineWebLinkTemplate method >", function() {
     it("should build an enhancement template for journal search results", function() {
       var data = serSol360Core.getData(journalResponse);
       var browzineWebLink = serSol360Core.getBrowZineWebLink(data);
-      var template = serSol360Core.buildTemplate(browzineWebLink);
+      var template = serSol360Core.browzineWebLinkTemplate(browzineWebLink);
 
       expect(data).toBeDefined();
       expect(browzineWebLink).toBeDefined();

--- a/tests/unit/models/360-core.js
+++ b/tests/unit/models/360-core.js
@@ -344,6 +344,18 @@ describe("SerSol 360 Core Model >", function() {
     });
   });
 
+  describe("serSol360Core model isDefaultCoverImage method >", function() {
+    it("should return false when an actual coverImageUrl is returned by the API", function() {
+      var coverImageUrl = "https://assets.thirdiron.com/images/covers/0028-4793.png";
+      expect(serSol360Core.isDefaultCoverImage(coverImageUrl)).toEqual(false);
+    });
+
+    it("should return true when a default coverImageUrl is returned by the API", function() {
+      var coverImageUrl = "https://assets.thirdiron.com/images/covers/default.png";
+      expect(serSol360Core.isDefaultCoverImage(coverImageUrl)).toEqual(true);
+    });
+  });
+
   describe("serSol360Core model buildTemplate method >", function() {
     it("should build an enhancement template for journal search results", function() {
       var data = serSol360Core.getData(journalResponse);

--- a/tests/unit/models/360-core.js
+++ b/tests/unit/models/360-core.js
@@ -366,10 +366,10 @@ describe("SerSol 360 Core Model >", function() {
       expect(browzineWebLink).toBeDefined();
       expect(template).toBeDefined();
 
-      expect(template).toEqual("<div class='browzine' style='margin: 5px 0;'><img class='browzine-book-icon' src='https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png' style='margin-top: -3px; display: inline;'/> <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/10292' target='_blank' style='font-weight: 300;'>View Journal in BrowZine</a></div>");
+      expect(template).toEqual("<div class='browzine' style='margin: 5px 0;'><img class='browzine-book-icon' src='https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png' style='margin-top: -3px; display: inline;'/> <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/10292' target='_blank' style='font-weight: 300;'>View Journal in BrowZine</a></div>");
       expect(template).toContain("View Journal in BrowZine");
       expect(template).toContain("https://browzine.com/libraries/XXX/journals/10292");
-      expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+      expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
       expect(template).toContain("margin: 5px 0;");
       expect(template).toContain("margin-top: -3px;");
       expect(template).toContain("font-weight: 300;");
@@ -384,7 +384,7 @@ describe("SerSol 360 Core Model >", function() {
         expect(template.text().trim()).toContain("View Journal in BrowZine");
         expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/XXX/journals/10292");
         expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
-        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
       })
     });
 

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -37,7 +37,8 @@ describe("Primo Model >", function() {
         "availableThroughBrowzine": true,
         "startPage": "h2575",
         "endPage": "h2575",
-        "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575"
+        "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575",
+        "fullTextFile": "https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file"
       },
       "included": [{
         "id": 18126,
@@ -626,6 +627,69 @@ describe("Primo Model >", function() {
     it("should return true when a default coverImageUrl is returned by the API", function() {
       var coverImageUrl = "https://assets.thirdiron.com/images/covers/default.png";
       expect(primo.isDefaultCoverImage(coverImageUrl)).toEqual(true);
+    });
+  });
+
+  describe("primo model getDirectToPDFUrl method >", function() {
+    it("should not include a fullTextFile property in the BrowZine API response for a journal", function() {
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["journal"]
+            },
+
+            addata: {
+              issn: ["0096-6762", "0028-4793"]
+            }
+          }
+        }
+      };
+
+      var data = primo.getData(journalResponse);
+
+      expect(data).toBeDefined();
+
+      expect(primo.getDirectToPDFUrl(scope, data)).toBeNull();
+    });
+
+    it("should include a fullTextFile property in the BrowZine API response for an article", function() {
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["article"]
+            },
+
+            addata: {
+              issn: ["0028-4793"],
+              doi: ["10.1136/bmj.h2575"]
+            }
+          }
+        }
+      };
+
+      var data = primo.getData(articleResponse);
+
+      expect(data).toBeDefined();
+
+      expect(primo.getDirectToPDFUrl(scope, data)).toEqual("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
+    });
+  });
+
+  describe("primo model showDirectToPDFLink method >", function() {
+    it("should show direct to pdf link when configuration property is undefined or null", function() {
+      expect(primo.showDirectToPDFLink()).toEqual(true);
+    });
+
+    it("should show direct to pdf link when configuration property is true", function() {
+      browzine.primoArticlePDFDownloadLinkEnabled = true;
+      expect(primo.showDirectToPDFLink()).toEqual(true);
+    });
+
+    it("should hide direct to pdf link when configuration property is false", function() {
+      browzine.primoArticlePDFDownloadLinkEnabled = false;
+      expect(primo.showDirectToPDFLink()).toEqual(false);
     });
   });
 

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -723,11 +723,11 @@ describe("Primo Model >", function() {
 
       expect(template).toBeDefined();
 
-      expect(template).toEqual("<div class='browzine' style='line-height: 1.4em;'><a class='browzine-direct-to-pdf-link' href='https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file' target='_blank'><img src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png' class='browzine-pdf-icon' style='margin-bottom: -1px; margin-right: 2.5px;' aria-hidden='true'/> <span class='browzine-web-link-text'>Download Now</span> <md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon></a></div>");
+      expect(template).toEqual("<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'><a class='browzine-direct-to-pdf-link' href='https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file' target='_blank'><img src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine-pdf-download-icon.png' class='browzine-pdf-icon' style='margin-bottom: -3px; margin-right: 2.8px;' aria-hidden='true' width='13'/> <span class='browzine-web-link-text'>Download Now</span> <md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon></a></div>");
 
       expect(template).toContain("Download Now");
       expect(template).toContain("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
-      expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png");
+      expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine-pdf-download-icon.png");
     });
   });
 
@@ -755,10 +755,10 @@ describe("Primo Model >", function() {
       expect(browzineWebLink).toBeDefined();
       expect(template).toBeDefined();
 
-      expect(template).toEqual("<div class='browzine' style='line-height: 1.4em;'><a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/10292' target='_blank'><img src='https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png' class='browzine-book-icon' style='margin-bottom: -1px; margin-right: 2.5px;' aria-hidden='true'/> <span class='browzine-web-link-text'>View Journal Contents</span> <md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon></a></div>");
+      expect(template).toEqual("<div class='browzine' style='line-height: 1.4em;'><a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/10292' target='_blank'><img src='https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png' class='browzine-book-icon' style='margin-bottom: -1px; margin-right: 2.5px;' aria-hidden='true'/> <span class='browzine-web-link-text'>View Journal Contents</span> <md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon></a></div>");
       expect(template).toContain("View Journal Contents");
       expect(template).toContain("https://browzine.com/libraries/XXX/journals/10292");
-      expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+      expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
     });
 
     it("should build an enhancement template for article search results", function() {
@@ -785,10 +785,10 @@ describe("Primo Model >", function() {
       expect(browzineWebLink).toBeDefined();
       expect(template).toBeDefined();
 
-      expect(template).toEqual("<div class='browzine' style='line-height: 1.4em;'><a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575' target='_blank'><img src='https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png' class='browzine-book-icon' style='margin-bottom: -1px; margin-right: 2.5px;' aria-hidden='true'/> <span class='browzine-web-link-text'>View Issue Contents</span> <md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon></a></div>");
+      expect(template).toEqual("<div class='browzine' style='line-height: 1.4em;'><a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575' target='_blank'><img src='https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png' class='browzine-book-icon' style='margin-bottom: -1px; margin-right: 2.5px;' aria-hidden='true'/> <span class='browzine-web-link-text'>View Issue Contents</span> <md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon></a></div>");
       expect(template).toContain("View Issue Contents");
       expect(template).toContain("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
-      expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+      expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
     });
   });
 });

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -631,7 +631,7 @@ describe("Primo Model >", function() {
   });
 
   describe("primo model getDirectToPDFUrl method >", function() {
-    it("should not include a fullTextFile property in the BrowZine API response for a journal", function() {
+    it("should not return a direct to pdf url for journal search results", function() {
       var scope = {
         result: {
           pnx: {
@@ -653,7 +653,7 @@ describe("Primo Model >", function() {
       expect(primo.getDirectToPDFUrl(scope, data)).toBeNull();
     });
 
-    it("should include a fullTextFile property in the BrowZine API response for an article", function() {
+    it("should return a direct to pdf url for article search results", function() {
       var scope = {
         result: {
           pnx: {
@@ -678,6 +678,10 @@ describe("Primo Model >", function() {
   });
 
   describe("primo model showDirectToPDFLink method >", function() {
+    beforeEach(function() {
+      delete browzine.primoArticlePDFDownloadLinkEnabled;
+    });
+
     afterEach(function() {
       delete browzine.primoArticlePDFDownloadLinkEnabled;
     });

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -617,6 +617,18 @@ describe("Primo Model >", function() {
     });
   });
 
+  describe("primo model isDefaultCoverImage method >", function() {
+    it("should return false when an actual coverImageUrl is returned by the API", function() {
+      var coverImageUrl = "https://assets.thirdiron.com/images/covers/0028-4793.png";
+      expect(primo.isDefaultCoverImage(coverImageUrl)).toEqual(false);
+    });
+
+    it("should return true when a default coverImageUrl is returned by the API", function() {
+      var coverImageUrl = "https://assets.thirdiron.com/images/covers/default.png";
+      expect(primo.isDefaultCoverImage(coverImageUrl)).toEqual(true);
+    });
+  });
+
   describe("primo model buildTemplate method >", function() {
     it("should build an enhancement template for journal search results", function() {
       var scope = {

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -678,6 +678,10 @@ describe("Primo Model >", function() {
   });
 
   describe("primo model showDirectToPDFLink method >", function() {
+    afterEach(function() {
+      delete browzine.primoArticlePDFDownloadLinkEnabled;
+    });
+
     it("should show direct to pdf link when configuration property is undefined or null", function() {
       expect(primo.showDirectToPDFLink()).toEqual(true);
     });
@@ -690,6 +694,40 @@ describe("Primo Model >", function() {
     it("should hide direct to pdf link when configuration property is false", function() {
       browzine.primoArticlePDFDownloadLinkEnabled = false;
       expect(primo.showDirectToPDFLink()).toEqual(false);
+    });
+  });
+
+  describe("primo model directToPDFTemplate method >", function() {
+    it("should build a direct to pdf template for article search results", function() {
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["article"]
+            },
+
+            addata: {
+              issn: ["0028-4793"],
+              doi: ["10.1136/bmj.h2575"]
+            }
+          }
+        }
+      };
+
+      var data = primo.getData(articleResponse);
+      var directToPDFUrl = primo.getDirectToPDFUrl(scope, data);
+      var template = primo.directToPDFTemplate(directToPDFUrl);
+
+      expect(data).toBeDefined();
+      expect(directToPDFUrl).toBeDefined();
+
+      expect(template).toBeDefined();
+
+      expect(template).toEqual("<div class='browzine' style='line-height: 1.4em;'><a class='browzine-direct-to-pdf-link' href='https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file' target='_blank'><img src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png' class='browzine-pdf-icon' style='margin-bottom: -1px; margin-right: 2.5px;' aria-hidden='true'/> <span class='browzine-web-link-text'>Download Now</span> <md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon></a></div>");
+
+      expect(template).toContain("Download Now");
+      expect(template).toContain("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
+      expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png");
     });
   });
 

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -693,7 +693,7 @@ describe("Primo Model >", function() {
     });
   });
 
-  describe("primo model buildTemplate method >", function() {
+  describe("primo model browzineWebLinkTemplate method >", function() {
     it("should build an enhancement template for journal search results", function() {
       var scope = {
         result: {
@@ -711,7 +711,7 @@ describe("Primo Model >", function() {
 
       var data = primo.getData(journalResponse);
       var browzineWebLink = primo.getBrowZineWebLink(data);
-      var template = primo.buildTemplate(scope, browzineWebLink);
+      var template = primo.browzineWebLinkTemplate(scope, browzineWebLink);
 
       expect(data).toBeDefined();
       expect(browzineWebLink).toBeDefined();
@@ -741,7 +741,7 @@ describe("Primo Model >", function() {
 
       var data = primo.getData(articleResponse);
       var browzineWebLink = primo.getBrowZineWebLink(data);
-      var template = primo.buildTemplate(scope, browzineWebLink);
+      var template = primo.browzineWebLinkTemplate(scope, browzineWebLink);
 
       expect(data).toBeDefined();
       expect(browzineWebLink).toBeDefined();

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -382,6 +382,36 @@ describe("Summon Model >", function() {
     });
   });
 
+  describe("summon model directToPDFTemplate method >", function() {
+    it("should build a direct to pdf template for article search results", function() {
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
+      var data = summon.getData(articleResponse);
+      var directToPDFUrl = summon.getDirectToPDFUrl(scope, data);
+      var template = summon.directToPDFTemplate(directToPDFUrl);
+
+      expect(data).toBeDefined();
+      expect(directToPDFUrl).toBeDefined();
+
+      expect(template).toBeDefined();
+
+      expect(template).toEqual("<div class='browzine'>Article PDF: <a class='browzine-direct-to-pdf-link' href='https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file' target='_blank' style='text-decoration: underline; color: #333;'>Download Now</a> <img class='browzine-pdf-icon' src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png'/></div>");
+
+      expect(template).toContain("Article PDF");
+      expect(template).toContain("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
+      expect(template).toContain("Download Now");
+      expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png");
+
+      expect(template).toContain("text-decoration: underline;");
+      expect(template).toContain("color: #333;");
+    });
+  });
+
   describe("summon model browzineWebLinkTemplate method >", function() {
     it("should build a browzine web link template for journal search results", function() {
       var scope = {
@@ -431,36 +461,6 @@ describe("Summon Model >", function() {
       expect(template).toContain("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
       expect(template).toContain("Browse Now");
       expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
-
-      expect(template).toContain("text-decoration: underline;");
-      expect(template).toContain("color: #333;");
-    });
-  });
-
-  describe("summon model directToPDFTemplate method >", function() {
-    it("should build a direct to pdf template for article search results", function() {
-      var scope = {
-        document: {
-          content_type: "Journal Article",
-          dois: ["10.1136/bmj.h2575"]
-        }
-      };
-
-      var data = summon.getData(articleResponse);
-      var directToPDFUrl = summon.getDirectToPDFUrl(scope, data);
-      var template = summon.directToPDFTemplate(directToPDFUrl);
-
-      expect(data).toBeDefined();
-      expect(directToPDFUrl).toBeDefined();
-
-      expect(template).toBeDefined();
-
-      expect(template).toEqual("<div class='browzine'>Article PDF: <a class='browzine-direct-to-pdf-link' href='https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file' target='_blank' style='text-decoration: underline; color: #333;'>Download Now</a> <img class='browzine-pdf-icon' src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png'/></div>");
-
-      expect(template).toContain("Article PDF");
-      expect(template).toContain("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
-      expect(template).toContain("Download Now");
-      expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png");
 
       expect(template).toContain("text-decoration: underline;");
       expect(template).toContain("color: #333;");

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -363,6 +363,10 @@ describe("Summon Model >", function() {
   });
 
   describe("summon model showDirectToPDFLink method >", function() {
+    afterEach(function() {
+      delete browzine.summonArticlePDFDownloadLinkEnabled;
+    });
+
     it("should show direct to pdf link when configuration property is undefined or null", function() {
       expect(summon.showDirectToPDFLink()).toEqual(true);
     });
@@ -414,17 +418,27 @@ describe("Summon Model >", function() {
 
       var data = summon.getData(articleResponse);
       var browzineWebLink = summon.getBrowZineWebLink(data);
-      var template = summon.buildTemplate(scope, browzineWebLink);
+      var directToPDFUrl = summon.getDirectToPDFUrl(scope, data);
+      var template = summon.buildTemplate(scope, browzineWebLink, directToPDFUrl);
 
       expect(data).toBeDefined();
       expect(browzineWebLink).toBeDefined();
+      expect(directToPDFUrl).toBeDefined();
+
       expect(template).toBeDefined();
 
-      expect(template).toEqual("<div class='browzine'>View Complete Issue: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png'/></div>");
+      expect(template).toEqual("<div class='browzine'>Article PDF: <a class='browzine-direct-to-pdf-link' href='https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file' target='_blank' style='text-decoration: underline; color: #333;'>Download Now</a> <img class='browzine-pdf-icon' src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png'/> <br/>View Complete Issue: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png'/></div>");
+
       expect(template).toContain("View Complete Issue");
       expect(template).toContain("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
       expect(template).toContain("Browse Now");
       expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+
+      expect(template).toContain("Article PDF");
+      expect(template).toContain("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
+      expect(template).toContain("Download Now");
+      expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png");
+
       expect(template).toContain("text-decoration: underline;");
       expect(template).toContain("color: #333;");
     });

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -28,7 +28,8 @@ describe("Summon Model >", function() {
         "availableThroughBrowzine": true,
         "startPage": "h2575",
         "endPage": "h2575",
-        "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575"
+        "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575",
+        "fullTextFile": "https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file"
       },
       "included": [{
         "id": 18126,
@@ -326,6 +327,54 @@ describe("Summon Model >", function() {
     it("should return true when a default coverImageUrl is returned by the API", function() {
       var coverImageUrl = "https://assets.thirdiron.com/images/covers/default.png";
       expect(summon.isDefaultCoverImage(coverImageUrl)).toEqual(true);
+    });
+  });
+
+  describe("summon model getDirectToPDFUrl method >", function() {
+    it("should not include a fullTextFile property in the BrowZine API response for a journal", function() {
+      var scope = {
+        document: {
+          content_type: "Journal",
+          issns: ["0082-3974"]
+        }
+      };
+
+      var data = summon.getData(journalResponse);
+
+      expect(data).toBeDefined();
+
+      expect(summon.getDirectToPDFUrl(scope, data)).toBeNull();
+    });
+
+    it("should include a fullTextFile property in the BrowZine API response for an article", function() {
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
+      var data = summon.getData(articleResponse);
+
+      expect(data).toBeDefined();
+
+      expect(summon.getDirectToPDFUrl(scope, data)).toEqual("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
+    });
+  });
+
+  describe("summon model showDirectToPDFLink method >", function() {
+    it("should show direct to pdf link when configuration property is undefined or null", function() {
+      expect(summon.showDirectToPDFLink()).toEqual(true);
+    });
+
+    it("should show direct to pdf link when configuration property is true", function() {
+      browzine.summonArticlePDFDownloadLinkEnabled = true;
+      expect(summon.showDirectToPDFLink()).toEqual(true);
+    });
+
+    it("should hide direct to pdf link when configuration property is false", function() {
+      browzine.summonArticlePDFDownloadLinkEnabled = false;
+      expect(summon.showDirectToPDFLink()).toEqual(false);
     });
   });
 

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -331,7 +331,7 @@ describe("Summon Model >", function() {
   });
 
   describe("summon model getDirectToPDFUrl method >", function() {
-    it("should not include a fullTextFile property in the BrowZine API response for a journal", function() {
+    it("should not return a direct to pdf url for journal search results", function() {
       var scope = {
         document: {
           content_type: "Journal",
@@ -346,7 +346,7 @@ describe("Summon Model >", function() {
       expect(summon.getDirectToPDFUrl(scope, data)).toBeNull();
     });
 
-    it("should include a fullTextFile property in the BrowZine API response for an article", function() {
+    it("should return a direct to pdf url for article search results", function() {
       var scope = {
         document: {
           content_type: "Journal Article",
@@ -363,6 +363,10 @@ describe("Summon Model >", function() {
   });
 
   describe("summon model showDirectToPDFLink method >", function() {
+    beforeEach(function() {
+      delete browzine.summonArticlePDFDownloadLinkEnabled;
+    });
+
     afterEach(function() {
       delete browzine.summonArticlePDFDownloadLinkEnabled;
     });

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -317,6 +317,18 @@ describe("Summon Model >", function() {
     });
   });
 
+  describe("summon model isDefaultCoverImage method >", function() {
+    it("should return false when an actual coverImageUrl is returned by the API", function() {
+      var coverImageUrl = "https://assets.thirdiron.com/images/covers/0028-4793.png";
+      expect(summon.isDefaultCoverImage(coverImageUrl)).toEqual(false);
+    });
+
+    it("should return true when a default coverImageUrl is returned by the API", function() {
+      var coverImageUrl = "https://assets.thirdiron.com/images/covers/default.png";
+      expect(summon.isDefaultCoverImage(coverImageUrl)).toEqual(true);
+    });
+  });
+
   describe("summon model buildTemplate method >", function() {
     it("should build an enhancement template for journal search results", function() {
       var scope = {

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -400,12 +400,12 @@ describe("Summon Model >", function() {
 
       expect(template).toBeDefined();
 
-      expect(template).toEqual("<div class='browzine'>Article PDF: <a class='browzine-direct-to-pdf-link' href='https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file' target='_blank' style='text-decoration: underline; color: #333;'>Download Now</a> <img class='browzine-pdf-icon' src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png'/></div>");
+      expect(template).toEqual("<div class='browzine'>Article PDF: <a class='browzine-direct-to-pdf-link' href='https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file' target='_blank' style='text-decoration: underline; color: #333;'>Download Now</a> <img class='browzine-pdf-icon' src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine-pdf-download-icon.png' width='12'/></div>");
 
       expect(template).toContain("Article PDF");
       expect(template).toContain("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");
       expect(template).toContain("Download Now");
-      expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png");
+      expect(template).toContain("https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine-pdf-download-icon.png");
 
       expect(template).toContain("text-decoration: underline;");
       expect(template).toContain("color: #333;");
@@ -429,11 +429,11 @@ describe("Summon Model >", function() {
       expect(browzineWebLink).toBeDefined();
       expect(template).toBeDefined();
 
-      expect(template).toEqual("<div class='browzine'>View the Journal: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/10292' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png'/></div>");
+      expect(template).toEqual("<div class='browzine'>View the Journal: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/10292' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png'/></div>");
       expect(template).toContain("View the Journal");
       expect(template).toContain("https://browzine.com/libraries/XXX/journals/10292");
       expect(template).toContain("Browse Now");
-      expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+      expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
       expect(template).toContain("text-decoration: underline;");
       expect(template).toContain("color: #333;");
     });
@@ -455,12 +455,12 @@ describe("Summon Model >", function() {
 
       expect(template).toBeDefined();
 
-      expect(template).toEqual("<div class='browzine'>View Complete Issue: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png'/></div>");
+      expect(template).toEqual("<div class='browzine'>View Complete Issue: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png'/></div>");
 
       expect(template).toContain("View Complete Issue");
       expect(template).toContain("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
       expect(template).toContain("Browse Now");
-      expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+      expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.png");
 
       expect(template).toContain("text-decoration: underline;");
       expect(template).toContain("color: #333;");

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -382,8 +382,8 @@ describe("Summon Model >", function() {
     });
   });
 
-  describe("summon model buildTemplate method >", function() {
-    it("should build an enhancement template for journal search results", function() {
+  describe("summon model browzineWebLinkTemplate method >", function() {
+    it("should build a browzine web link template for journal search results", function() {
       var scope = {
         document: {
           content_type: "Journal",
@@ -393,7 +393,7 @@ describe("Summon Model >", function() {
 
       var data = summon.getData(journalResponse);
       var browzineWebLink = summon.getBrowZineWebLink(data);
-      var template = summon.buildTemplate(scope, browzineWebLink);
+      var template = summon.browzineWebLinkTemplate(scope, browzineWebLink);
 
       expect(data).toBeDefined();
       expect(browzineWebLink).toBeDefined();
@@ -408,7 +408,7 @@ describe("Summon Model >", function() {
       expect(template).toContain("color: #333;");
     });
 
-    it("should build an enhancement template for article search results", function() {
+    it("should build a browzine web link template for article search results", function() {
       var scope = {
         document: {
           content_type: "Journal Article",
@@ -418,21 +418,44 @@ describe("Summon Model >", function() {
 
       var data = summon.getData(articleResponse);
       var browzineWebLink = summon.getBrowZineWebLink(data);
-      var directToPDFUrl = summon.getDirectToPDFUrl(scope, data);
-      var template = summon.buildTemplate(scope, browzineWebLink, directToPDFUrl);
+      var template = summon.browzineWebLinkTemplate(scope, browzineWebLink);
 
       expect(data).toBeDefined();
       expect(browzineWebLink).toBeDefined();
-      expect(directToPDFUrl).toBeDefined();
 
       expect(template).toBeDefined();
 
-      expect(template).toEqual("<div class='browzine'>Article PDF: <a class='browzine-direct-to-pdf-link' href='https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file' target='_blank' style='text-decoration: underline; color: #333;'>Download Now</a> <img class='browzine-pdf-icon' src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png'/> <br/>View Complete Issue: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png'/></div>");
+      expect(template).toEqual("<div class='browzine'>View Complete Issue: <a class='browzine-web-link' href='https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575' target='_blank' style='text-decoration: underline; color: #333;'>Browse Now</a> <img class='browzine-book-icon' src='https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png'/></div>");
 
       expect(template).toContain("View Complete Issue");
       expect(template).toContain("https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575");
       expect(template).toContain("Browse Now");
       expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine_open_book_icon.png");
+
+      expect(template).toContain("text-decoration: underline;");
+      expect(template).toContain("color: #333;");
+    });
+  });
+
+  describe("summon model directToPDFTemplate method >", function() {
+    it("should build a direct to pdf template for article search results", function() {
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
+      var data = summon.getData(articleResponse);
+      var directToPDFUrl = summon.getDirectToPDFUrl(scope, data);
+      var template = summon.directToPDFTemplate(directToPDFUrl);
+
+      expect(data).toBeDefined();
+      expect(directToPDFUrl).toBeDefined();
+
+      expect(template).toBeDefined();
+
+      expect(template).toEqual("<div class='browzine'>Article PDF: <a class='browzine-direct-to-pdf-link' href='https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file' target='_blank' style='text-decoration: underline; color: #333;'>Download Now</a> <img class='browzine-pdf-icon' src='https://s3.amazonaws.com/thirdiron-assets/images/integrations/browzine_pdf_download_icon.png'/></div>");
 
       expect(template).toContain("Article PDF");
       expect(template).toContain("https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file");


### PR DESCRIPTION
## Summary - [BZ-4508](https://thirdiron.atlassian.net/browse/BZ-4508)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Add Direct To PDF Link when available - Primo and Summon

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

Tasks:
- Add Direct To PDF Link when available - Primo (priority) && Summon (DONE)
Primo (DONE)
Summon (DONE)
Unit and Acceptance Tests (DONE)
Cross Browser Tests (Chrome, FF, Safari, IE11, Edge) (DONE)
- Summon: Refactor template to position "Article PDF" the first entry (DONE)
- Primo: Refactor template to align "Download PDF" with native "Available Online" Link (DONE)
- Override the default link text shown (DONE)
- On by default, but can disable with a config flag (DONE)
- Remove browzineEnabled check for CoverImages (DONE)
- Always update the Journal Cover when available, unless the Journal Cover is the default image (DONE)


**Screenshots**

Primo

![image](https://user-images.githubusercontent.com/376230/43652639-c3017446-9713-11e8-9b65-1c2cbd622bb4.png)

Summon

![image](https://user-images.githubusercontent.com/376230/43559685-0893706e-95dd-11e8-856c-2599b1ed6f8d.png)



## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None
