### PR TITLE
feature/add-journal-cover-to-articles-without-doi-BZ-5406

### DIFF
--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -108,12 +108,17 @@ browzine.primo = (function() {
   function getEndpoint(scope) {
     var endpoint = "";
 
-    if(isArticle(scope)) {
+    if(isJournal(scope) && getIssn(scope)) {
+      var issn = getIssn(scope);
+      endpoint = api + "/search?issns=" + issn;
+    }
+
+    if(isArticle(scope) && getDoi(scope)) {
       var doi = getDoi(scope);
       endpoint = api + "/articles/doi/" + doi + "?include=journal";
     }
 
-    if(isJournal(scope)) {
+    if(isArticle(scope) && !getDoi(scope) && getIssn(scope)) {
       var issn = getIssn(scope);
       endpoint = api + "/search?issns=" + issn;
     }
@@ -160,15 +165,21 @@ browzine.primo = (function() {
   function getCoverImageUrl(scope, data, journal) {
     var coverImageUrl = null;
 
-    if(isJournal(scope)) {
+    if(isJournal(scope) && getIssn(scope)) {
       if(data && data.coverImageUrl) {
         coverImageUrl = data.coverImageUrl;
       }
     }
 
-    if(isArticle(scope)) {
+    if(isArticle(scope) && getDoi(scope)) {
       if(journal && journal.coverImageUrl) {
         coverImageUrl = journal.coverImageUrl;
+      }
+    }
+
+    if(isArticle(scope) && !getDoi(scope) && getIssn(scope)) {
+      if(data && data.coverImageUrl) {
+        coverImageUrl = data.coverImageUrl;
       }
     }
 
@@ -401,6 +412,10 @@ browzine.primo = (function() {
       }
 
       if(isArticle(scope) && getDoi(scope)) {
+        validation = true;
+      }
+
+      if(isArticle(scope) && !getDoi(scope) && getIssn(scope)) {
         validation = true;
       }
     }

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -84,12 +84,17 @@ browzine.summon = (function() {
   function getEndpoint(scope) {
     var endpoint = "";
 
-    if(isArticle(scope)) {
+    if(isJournal(scope) && getIssn(scope)) {
+      var issn = getIssn(scope);
+      endpoint = api + "/search?issns=" + issn;
+    }
+
+    if(isArticle(scope) && getDoi(scope)) {
       var doi = getDoi(scope);
       endpoint = api + "/articles/doi/" + doi + "?include=journal";
     }
 
-    if(isJournal(scope)) {
+    if(isArticle(scope) && !getDoi(scope) && getIssn(scope)) {
       var issn = getIssn(scope);
       endpoint = api + "/search?issns=" + issn;
     }
@@ -126,15 +131,21 @@ browzine.summon = (function() {
   function getCoverImageUrl(scope, data, journal) {
     var coverImageUrl = null;
 
-    if(isJournal(scope)) {
+    if(isJournal(scope) && getIssn(scope)) {
       if(data && data.coverImageUrl) {
         coverImageUrl = data.coverImageUrl;
       }
     }
 
-    if(isArticle(scope)) {
+    if(isArticle(scope) && getDoi(scope)) {
       if(journal && journal.coverImageUrl) {
         coverImageUrl = journal.coverImageUrl;
+      }
+    }
+
+    if(isArticle(scope) && !getDoi(scope) && getIssn(scope)) {
+      if(data && data.coverImageUrl) {
+        coverImageUrl = data.coverImageUrl;
       }
     }
 
@@ -350,6 +361,10 @@ browzine.summon = (function() {
       }
 
       if(isArticle(scope) && getDoi(scope)) {
+        validation = true;
+      }
+
+      if(isArticle(scope) && !getDoi(scope) && getIssn(scope)) {
         validation = true;
       }
     }

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -307,6 +307,88 @@ describe("BrowZine Primo Adapter >", function() {
       });
     });
 
+    describe("search results article with a journal issn but no article doi >", function() {
+      beforeEach(function() {
+        primo = browzine.primo;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.$ctrl = {
+            parentCtrl: {
+              result: {
+                pnx: {
+                  display: {
+                    type: ["article"]
+                  },
+
+                  addata: {
+                    issn: ["0096-6762", "0028-4793"]
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$ctrl.parentCtrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": [{
+              "id": 10292,
+              "type": "journals",
+              "title": "New England Journal of Medicine (NEJM)",
+              "issn": "00284793",
+              "sjrValue": 14.619,
+              "coverImageUrl": "https://assets.thirdiron.com/images/covers/0028-4793.png",
+              "browzineEnabled": true,
+              "browzineWebLink": "https://browzine.com/libraries/XXX/journals/10292"
+            }, {
+              "id": 10289,
+              "type": "journals",
+              "title": "The Boston Medical and Surgical Journal",
+              "issn": "00966762",
+              "sjrValue": 0,
+              "coverImageUrl": "https://assets.thirdiron.com/default-journal-cover.png",
+              "browzineEnabled": false,
+              "externalLink": "http://za2uf4ps7f.search.serialssolutions.com/?V=1.0&N=100&L=za2uf4ps7f&S=I_M&C=0096-6762"
+            }]
+          })
+        });
+
+        expect(request.url).toMatch(/search\?issns=00966762%2C00284793/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should have an enhanced browzine journal cover", function(done) {
+        requestAnimationFrame(function() {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+
+          Array.prototype.forEach.call(coverImages, function(coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
+          });
+
+          done();
+        });
+      });
+    });
+
     describe("search results article with no direct to pdf link and an article link >", function() {
       beforeEach(function() {
         browzine.articleLinkEnabled = true;

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -41,10 +41,6 @@ describe("BrowZine Summon Adapter >", function() {
         summon.adapter(documentSummary);
       });
 
-      afterEach(function() {
-
-      });
-
       it("should have an enhanced browse journal in browzine option", function() {
         var template = documentSummary.find(".browzine");
         expect(template).toBeDefined();
@@ -177,10 +173,6 @@ describe("BrowZine Summon Adapter >", function() {
         summon.adapter(documentSummary);
       });
 
-      afterEach(function() {
-
-      });
-
       it("should have an enhanced browse article in browzine option", function() {
         var template = documentSummary.find(".browzine");
 
@@ -240,10 +232,6 @@ describe("BrowZine Summon Adapter >", function() {
         };
 
         summon.adapter(documentSummary);
-      });
-
-      afterEach(function() {
-
       });
 
       it("should have an enhanced browzine journal cover", function() {

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -205,6 +205,54 @@ describe("BrowZine Summon Adapter >", function() {
       });
     });
 
+    describe("search results article with a journal issn but no article doi >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            issns: ["0028-4793"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        $.getJSON = function(endpoint, callback) {
+          expect(endpoint).toMatch(/search\?issns=00284793/);
+
+          return callback({
+            "data": [{
+              "id": 10292,
+              "type": "journals",
+              "title": "New England Journal of Medicine (NEJM)",
+              "issn": "00284793",
+              "sjrValue": 14.619,
+              "coverImageUrl": "https://assets.thirdiron.com/images/covers/0028-4793.png",
+              "browzineEnabled": true,
+              "browzineWebLink": "https://browzine.com/libraries/XXX/journals/10292"
+            }]
+          });
+        };
+
+        summon.adapter(documentSummary);
+      });
+
+      afterEach(function() {
+
+      });
+
+      it("should have an enhanced browzine journal cover", function() {
+        var coverImage = documentSummary.find(".coverImage img");
+        expect(coverImage).toBeDefined();
+        expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
+      });
+    });
+
     describe("search results article with no direct to pdf link and an article link >", function() {
       beforeEach(function() {
         browzine.articleLinkEnabled = true;

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -312,7 +312,26 @@ describe("Primo Model >", function() {
       expect(primo.shouldEnhance(scope)).toEqual(false);
     });
 
-    it("should not enhance an article search result without a doi", function() {
+    it("should not enhance an article search result without a doi or issn", function() {
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["article"]
+            },
+
+            addata: {
+              issn: [],
+              doi: []
+            }
+          }
+        }
+      };
+
+      expect(primo.shouldEnhance(scope)).toEqual(false);
+    });
+
+    it("should enhance an article search result journal cover with an issn even without a doi", function() {
       var scope = {
         result: {
           pnx: {
@@ -328,7 +347,7 @@ describe("Primo Model >", function() {
         }
       };
 
-      expect(primo.shouldEnhance(scope)).toEqual(false);
+      expect(primo.shouldEnhance(scope)).toEqual(true);
     });
 
     it("should not enhance a journal search result without a content type", function() {
@@ -557,6 +576,24 @@ describe("Primo Model >", function() {
 
       expect(primo.getEndpoint(scope)).toContain("articles/doi/10.1136%2Fbmj.h2575?include=journal");
     });
+
+    it("should build a journal endpoint for an article search result with a journal issn but no article doi", function() {
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["article"]
+            },
+
+            addata: {
+              issn: ["0028-4793"]
+            }
+          }
+        }
+      };
+
+      expect(primo.getEndpoint(scope)).toContain("search?issns=00284793");
+    });
   });
 
   describe("primo model getBrowZineWebLink method >", function() {
@@ -621,6 +658,30 @@ describe("Primo Model >", function() {
       expect(journal).toBeDefined();
 
       expect(primo.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
+    });
+
+    it("should include a coverImageUrl in the BrowZine API response for an article with a journal issn but no article doi", function() {
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["article"]
+            },
+
+            addata: {
+              issn: ["0096-6762", "0028-4793"]
+            }
+          }
+        }
+      };
+
+      var data = primo.getData(journalResponse);
+      var journal = primo.getIncludedJournal(journalResponse);
+
+      expect(data).toBeDefined();
+      expect(journal).toBeNull();
+
+      expect(primo.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
     });
   });
 

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -192,7 +192,7 @@ describe("Summon Model >", function() {
       expect(summon.shouldEnhance(scope)).toEqual(false);
     });
 
-    it("should not enhance an article search result without a doi", function() {
+    it("should not enhance an article search result without a doi or issn", function() {
       var scope = {
         document: {
           content_type: "Journal Article"
@@ -200,6 +200,17 @@ describe("Summon Model >", function() {
       };
 
       expect(summon.shouldEnhance(scope)).toEqual(false);
+    });
+
+    it("should enhance an article search result journal cover with an issn even without a doi", function() {
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          issns: ["0028-4793"]
+        }
+      };
+
+      expect(summon.shouldEnhance(scope)).toEqual(true);
     });
 
     it("should not enhance a journal search result without a content type", function() {
@@ -279,6 +290,17 @@ describe("Summon Model >", function() {
 
       expect(summon.getEndpoint(scope)).toContain("articles/doi/10.1136%2Fbmj.h2575?include=journal");
     });
+
+    it("should build a journal endpoint for an article search result with a journal issn but no article doi", function() {
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          issns: ["0028-4793"]
+        }
+      };
+
+      expect(summon.getEndpoint(scope)).toContain("search?issns=00284793");
+    });
   });
 
   describe("summon model getBrowZineWebLink method >", function() {
@@ -328,6 +350,23 @@ describe("Summon Model >", function() {
       expect(journal).toBeDefined();
 
       expect(summon.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0959-8138.png");
+    });
+
+    it("should include a coverImageUrl in the BrowZine API response for an article with a journal issn but no article doi", function() {
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          issns: ["0082-3974"]
+        }
+      };
+
+      var data = summon.getData(journalResponse);
+      var journal = summon.getIncludedJournal(journalResponse);
+
+      expect(data).toBeDefined();
+      expect(journal).toBeNull();
+
+      expect(summon.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
     });
   });
 


### PR DESCRIPTION
## Summary - [BZ-5406](https://thirdiron.atlassian.net/browse/BZ-5406)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Adds journal cover image to article search results with a journal issn but no article doi.


### Description

TOOD:
- Review Regression Tests (DONE)


## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->


- None
