### PR TITLE
feature/always-show-open-access-articles-BZ-6812

### DIFF
--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -649,7 +649,7 @@ browzine.primo = (function() {
 
         var element = getElement(scope);
 
-        if (directToPDFUrl && isArticle(scope) && showDirectToPDFLink() && browzineEnabled) {
+        if (directToPDFUrl && isArticle(scope) && showDirectToPDFLink()) {
           var template = directToPDFTemplate(directToPDFUrl);
 
           (function poll() {
@@ -664,7 +664,7 @@ browzine.primo = (function() {
           })();
         }
 
-        if (!directToPDFUrl && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink() && browzineEnabled) {
+        if (!directToPDFUrl && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
           var template = articleLinkTemplate(articleLinkUrl);
 
           (function poll() {

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -610,12 +610,12 @@ browzine.summon = (function() {
         var directToPDFUrl = getDirectToPDFUrl(scope, data);
         var articleLinkUrl = getArticleLinkUrl(scope, data);
 
-        if (directToPDFUrl && isArticle(scope) && showDirectToPDFLink() && browzineEnabled) {
+        if (directToPDFUrl && isArticle(scope) && showDirectToPDFLink()) {
           var template = directToPDFTemplate(directToPDFUrl);
           $(documentSummary).find(".docFooter .row:eq(0)").prepend(template);
         }
 
-        if (!directToPDFUrl && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink() && browzineEnabled) {
+        if (!directToPDFUrl && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
           var template = articleLinkTemplate(articleLinkUrl);
           $(documentSummary).find(".docFooter .row:eq(0)").prepend(template);
         }

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -1939,7 +1939,7 @@ describe("BrowZine Primo Adapter >", function() {
       });
     });
 
-    fdescribe("search results open access article with a direct to pdf link and journal not browzineEnabled >", function() {
+    describe("search results open access article with a direct to pdf link and journal not browzineEnabled >", function() {
       beforeEach(function() {
         primo = browzine.primo;
 

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -1938,6 +1938,116 @@ describe("BrowZine Primo Adapter >", function() {
         });
       });
     });
+
+    fdescribe("search results open access article with a direct to pdf link and journal not browzineEnabled >", function() {
+      beforeEach(function() {
+        primo = browzine.primo;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.$ctrl = {
+            parentCtrl: {
+              result: {
+                pnx: {
+                  display: {
+                    type: ["article"]
+                  },
+
+                  addata: {
+                    issn: ["21582440"],
+                    doi: ["10.1177/2158244020915900"]
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$ctrl.parentCtrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 379795373,
+              "type": "articles",
+              "title": "From Open Access to Open Science: The Path From Scientific Reality to Open Scientific Communication",
+              "date": "2020-05-10",
+              "doi": "10.1177/2158244020915900",
+              "authors": "Heise, Christian; Pearce, Joshua M.",
+              "inPress": false,
+              "openAccess": true,
+              "pmid": "",
+              "availableThroughBrowzine": false,
+              "startPage": "215824402091590",
+              "endPage": "",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/379795373/content-location",
+              "fullTextFile": "https://develop.libkey.io/libraries/XXXX/articles/379795373/full-text-file",
+              "ILLURL": "https://illiad.mines.edu/illiad//illiad.dll?Action=10&Form=30&&rft.genre=article&rft.aulast=Heise&rft.issn=2158-2440&rft.jtitle=SAGE%20Open&rft.atitle=From%20Open%20Access%20to%20Open%20Science%3A%20The%20Path%20From%20Scientific%20Reality%20to%20Open%20Scientific%20Communication&rft.volume=10&rft.issue=2&rft.spage=215824402091590&rft.epage=&rft.date=2020-05-10&rfr_id=BrowZine"
+            },
+            "included": [{
+              "id": 18126,
+              "type": "journals",
+              "title": "SAGE Open",
+              "issn": "21582440",
+              "sjrValue": 0.248,
+              "coverImageUrl": "https://assets.thirdiron.com/images/covers/2158-2440.png",
+              "browzineEnabled": false,
+              "externalLink": "https://mines.primo.exlibrisgroup.com/discovery/search?query=issn,contains,2158-2440,AND&pfilter=rtype,exact,journals,AND&tab=Everything&search_scope=MyInst_and_CI&sortby=rank&vid=01COLSCHL_INST:MINES&lang=en&mode=advanced&offset=0"
+            }]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1177%2F2158244020915900/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should have an enhanced browse article in browzine option", function() {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("Download PDF");
+
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/articles/379795373/full-text-file");
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-pdf-download-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function(done) {
+        requestAnimationFrame(function() {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function(coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/2158-2440.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when a direct to pdf link is clicked", function() {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-direct-to-pdf-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/articles/379795373/full-text-file", "_blank");
+      });
+    });
   });
 
   describe("search results without scope data >", function() {

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -1668,5 +1668,95 @@ describe("BrowZine Summon Adapter >", function() {
         });
       });
     });
+
+    describe("search results open access article with a direct to pdf link and journal not browzineEnabled >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1177/2158244020915900"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 379795373,
+              "type": "articles",
+              "title": "From Open Access to Open Science: The Path From Scientific Reality to Open Scientific Communication",
+              "date": "2020-05-10",
+              "doi": "10.1177/2158244020915900",
+              "authors": "Heise, Christian; Pearce, Joshua M.",
+              "inPress": false,
+              "openAccess": true,
+              "pmid": "",
+              "availableThroughBrowzine": false,
+              "startPage": "215824402091590",
+              "endPage": "",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/379795373/content-location",
+              "fullTextFile": "https://develop.libkey.io/libraries/XXXX/articles/379795373/full-text-file",
+              "ILLURL": "https://illiad.mines.edu/illiad//illiad.dll?Action=10&Form=30&&rft.genre=article&rft.aulast=Heise&rft.issn=2158-2440&rft.jtitle=SAGE%20Open&rft.atitle=From%20Open%20Access%20to%20Open%20Science%3A%20The%20Path%20From%20Scientific%20Reality%20to%20Open%20Scientific%20Communication&rft.volume=10&rft.issue=2&rft.spage=215824402091590&rft.epage=&rft.date=2020-05-10&rfr_id=BrowZine"
+            },
+            "included": [{
+              "id": 18126,
+              "type": "journals",
+              "title": "SAGE Open",
+              "issn": "21582440",
+              "sjrValue": 0.248,
+              "coverImageUrl": "https://assets.thirdiron.com/images/covers/2158-2440.png",
+              "browzineEnabled": false,
+              "externalLink": "https://mines.primo.exlibrisgroup.com/discovery/search?query=issn,contains,2158-2440,AND&pfilter=rtype,exact,journals,AND&tab=Everything&search_scope=MyInst_and_CI&sortby=rank&vid=01COLSCHL_INST:MINES&lang=en&mode=advanced&offset=0"
+            }]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1177%2F2158244020915900/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should have an enhanced browse article in browzine option", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("Article PDF Download Now");
+
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/articles/379795373/full-text-file");
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-pdf-download-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function() {
+        var coverImage = documentSummary.find(".coverImage img");
+        expect(coverImage).toBeDefined();
+        expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/2158-2440.png");
+      });
+
+      it("should open a new window when a direct to pdf link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-direct-to-pdf-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/articles/379795373/full-text-file", "_blank");
+      });
+    });
   });
 });


### PR DESCRIPTION


## Summary - [BZ-6812](https://thirdiron.atlassian.net/browse/BZ-6812)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Always show open access articles even when journal not browzineEnabled 

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

e.g. http://msulibrariestest.summon.serialssolutions.com/#!/search?ho=t&fvf=ContentType,Journal%20Article,f&l=en&q=From%20Open%20Access%20to%20Open%20Science:%20The%20Path%20From%20Scientific%20Reality%20to%20Open%20Scientific%20Communication
![image](https://user-images.githubusercontent.com/376230/132399901-fbcb3b47-46b3-4103-b60a-15f6c0240763.png)




## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->


- None
