### PR TITLE
feature/remove-one-link-by-default-BZ-6736

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ var browzine = {
   articleLinkTextWording: "Article Link",
   articleLinkText: "Read Article",
 
+  showSummonFullTextOnlineLink: true,
+
   unpaywallEmailAddressKey: "enter-your-email@your-institution-domain.edu",
 
   articlePDFDownloadViaUnpaywallEnabled: true,
@@ -226,6 +228,8 @@ window.browzine = {
   articleLinkText: "Read Article",
 
   printRecordsIntegrationEnabled: true,
+
+  showPrimoOnlineAccessLink: true,
 
   unpaywallEmailAddressKey: "enter-your-email@your-institution-domain.edu",
 

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -413,6 +413,17 @@ browzine.primo = (function() {
     return featureEnabled;
   };
 
+  function showOneLink() {
+    var featureEnabled = false;
+    var config = browzine.showPrimoOnlineAccessLink;
+
+    if (typeof config === "undefined" || config === null || config === true) {
+      featureEnabled = true;
+    }
+
+    return featureEnabled;
+  };
+
   function isFiltered(scope) {
     var validation = false;
     var result = getResult(scope);
@@ -792,6 +803,7 @@ browzine.primo = (function() {
     showDirectToPDFLink: showDirectToPDFLink,
     showArticleLink: showArticleLink,
     showPrintRecords: showPrintRecords,
+    showOneLink: showOneLink,
     transition: transition,
     directToPDFTemplate: directToPDFTemplate,
     articleLinkTemplate: articleLinkTemplate,

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -401,6 +401,17 @@ browzine.summon = (function() {
     return featureEnabled;
   };
 
+  function showOneLink() {
+    var featureEnabled = false;
+    var config = browzine.showSummonFullTextOnlineLink;
+
+    if (typeof config === "undefined" || config === null || config === true) {
+      featureEnabled = true;
+    }
+
+    return featureEnabled;
+  };
+
   function isFiltered(scope) {
     var result = false;
 
@@ -706,6 +717,7 @@ browzine.summon = (function() {
     showDirectToPDFLink: showDirectToPDFLink,
     showArticleLink: showArticleLink,
     showPrintRecords: showPrintRecords,
+    showOneLink: showOneLink,
     isFiltered: isFiltered,
     transition: transition,
     browzineWebLinkTemplate: browzineWebLinkTemplate,

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -1602,6 +1602,30 @@ describe("Primo Model >", function() {
     });
   });
 
+  describe("primo model showOneLink method >", function() {
+    beforeEach(function() {
+      delete browzine.showPrimoOnlineAccessLink;
+    });
+
+    afterEach(function() {
+      delete browzine.showPrimoOnlineAccessLink;
+    });
+
+    it("should disable onelink when configuration property is undefined or null", function() {
+      expect(primo.showOneLink()).toEqual(true);
+    });
+
+    it("should disable onelink when configuration property is true", function() {
+      browzine.showPrimoOnlineAccessLink = true;
+      expect(primo.showOneLink()).toEqual(true);
+    });
+
+    it("should not disable onelink when configuration property is false", function() {
+      browzine.showPrimoOnlineAccessLink = false;
+      expect(primo.showOneLink()).toEqual(false);
+    });
+  });
+
   describe("primo model isFiltered method >", function() {
     beforeEach(function() {
       delete browzine.printRecordsIntegrationEnabled;

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -1156,6 +1156,30 @@ describe("Summon Model >", function() {
     });
   });
 
+  describe("summon model showOneLink method >", function() {
+    beforeEach(function() {
+      delete browzine.showSummonFullTextOnlineLink;
+    });
+
+    afterEach(function() {
+      delete browzine.showSummonFullTextOnlineLink;
+    });
+
+    it("should disable onelink when configuration property is undefined or null", function() {
+      expect(summon.showOneLink()).toEqual(true);
+    });
+
+    it("should disable onelink when configuration property is true", function() {
+      browzine.showSummonFullTextOnlineLink = true;
+      expect(summon.showOneLink()).toEqual(true);
+    });
+
+    it("should not disable onelink when configuration property is false", function() {
+      browzine.showSummonFullTextOnlineLink = false;
+      expect(summon.showOneLink()).toEqual(false);
+    });
+  });
+
   describe("summon model isFiltered method >", function() {
     beforeEach(function() {
       delete browzine.printRecordsIntegrationEnabled;


### PR DESCRIPTION
## Summary - [BZ-6736](https://thirdiron.atlassian.net/browse/BZ-6736)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Initial PR to disable OneLink in Summon and Primo; Adds config options and config options unit tests.

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

TODO:
- Add configuration properties (**DONE**)
- Implement hiding OneLink when enabled (**INPROGRESS**)


## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->


- None
