### PR TITLE
feature/one-link-management-BZ-6848

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ var browzine = {
   articleLinkTextWording: "Article Link",
   articleLinkText: "Read Article",
 
+  showSummonFullTextOnlineLink: true,
+
   unpaywallEmailAddressKey: "enter-your-email@your-institution-domain.edu",
 
   articlePDFDownloadViaUnpaywallEnabled: true,
@@ -226,6 +228,8 @@ window.browzine = {
   articleLinkText: "Read Article",
 
   printRecordsIntegrationEnabled: true,
+
+  showPrimoOnlineAccessLink: true,
 
   unpaywallEmailAddressKey: "enter-your-email@your-institution-domain.edu",
 

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -720,7 +720,7 @@ browzine.primo = (function() {
           var oneLinkElement = elementParent.querySelector("prm-search-result-availability-line .layout-align-start-start .layout-row");
 
           if (oneLinkElement) {
-            oneLinkElement.remove();
+            // oneLinkElement.remove();
           }
         }
       }

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -720,7 +720,7 @@ browzine.primo = (function() {
           var oneLinkElement = elementParent.querySelector("prm-search-result-availability-line .layout-align-start-start .layout-row");
 
           if (oneLinkElement) {
-            // oneLinkElement.remove();
+            oneLinkElement.remove();
           }
         }
       }

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -413,6 +413,17 @@ browzine.primo = (function() {
     return featureEnabled;
   };
 
+  function showOneLink() {
+    var featureEnabled = false;
+    var config = browzine.showPrimoOnlineAccessLink;
+
+    if (typeof config === "undefined" || config === null || config === true) {
+      featureEnabled = true;
+    }
+
+    return featureEnabled;
+  };
+
   function isFiltered(scope) {
     var validation = false;
     var result = getResult(scope);
@@ -792,6 +803,7 @@ browzine.primo = (function() {
     showDirectToPDFLink: showDirectToPDFLink,
     showArticleLink: showArticleLink,
     showPrintRecords: showPrintRecords,
+    showOneLink: showOneLink,
     transition: transition,
     directToPDFTemplate: directToPDFTemplate,
     articleLinkTemplate: articleLinkTemplate,

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -714,6 +714,15 @@ browzine.primo = (function() {
             }
           })();
         }
+
+        if (!showOneLink() && (directToPDFUrl || articleLinkUrl)) {
+          var elementParent = getElementParent(element);
+          var oneLinkElement = elementParent.querySelector("prm-search-result-availability-line .layout-align-start-start .layout-row");
+
+          if (oneLinkElement) {
+            oneLinkElement.remove();
+          }
+        }
       }
 
       if ((request.readyState == XMLHttpRequest.DONE && request.status == 404) || (isArticle(scope) && (!directToPDFUrl && !articleLinkUrl))) {
@@ -754,6 +763,21 @@ browzine.primo = (function() {
 
                   if (availabilityLine) {
                     availabilityLine.insertAdjacentHTML('afterbegin', template);
+                  } else {
+                    requestAnimationFrame(poll);
+                  }
+                })();
+              }
+
+              if (!showOneLink() && template) {
+                var element = getElement(scope);
+
+                (function poll() {
+                  var elementParent = getElementParent(element);
+                  var oneLinkElement = elementParent.querySelector("prm-search-result-availability-line .layout-align-start-start .layout-row");
+
+                  if (oneLinkElement) {
+                    oneLinkElement.remove();
                   } else {
                     requestAnimationFrame(poll);
                   }

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -646,7 +646,7 @@ browzine.summon = (function() {
         }
 
         if (!showOneLink() && (directToPDFUrl || articleLinkUrl)) {
-          const oneLinkElement = $(documentSummary).find(".availabilityContent");
+          var oneLinkElement = $(documentSummary).find(".availabilityContent");
 
           if (oneLinkElement) {
             oneLinkElement.remove();
@@ -688,7 +688,7 @@ browzine.summon = (function() {
               }
 
               if (!showOneLink() && template) {
-                const oneLinkElement = $(documentSummary).find(".availabilityContent");
+                var oneLinkElement = $(documentSummary).find(".availabilityContent");
 
                 if (oneLinkElement) {
                   oneLinkElement.remove();

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -649,7 +649,7 @@ browzine.summon = (function() {
           var oneLinkElement = $(documentSummary).find(".availabilityContent");
 
           if (oneLinkElement) {
-            // oneLinkElement.remove();
+            oneLinkElement.remove();
           }
         }
       }

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -649,7 +649,7 @@ browzine.summon = (function() {
           var oneLinkElement = $(documentSummary).find(".availabilityContent");
 
           if (oneLinkElement) {
-            oneLinkElement.remove();
+            // oneLinkElement.remove();
           }
         }
       }

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -401,6 +401,17 @@ browzine.summon = (function() {
     return featureEnabled;
   };
 
+  function showOneLink() {
+    var featureEnabled = false;
+    var config = browzine.showSummonFullTextOnlineLink;
+
+    if (typeof config === "undefined" || config === null || config === true) {
+      featureEnabled = true;
+    }
+
+    return featureEnabled;
+  };
+
   function isFiltered(scope) {
     var result = false;
 
@@ -706,6 +717,7 @@ browzine.summon = (function() {
     showDirectToPDFLink: showDirectToPDFLink,
     showArticleLink: showArticleLink,
     showPrintRecords: showPrintRecords,
+    showOneLink: showOneLink,
     isFiltered: isFiltered,
     transition: transition,
     browzineWebLinkTemplate: browzineWebLinkTemplate,

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -644,6 +644,14 @@ browzine.summon = (function() {
         if (coverImageUrl && !defaultCoverImage && showJournalCoverImages()) {
           $(documentSummary).find(".coverImage img").attr("src", coverImageUrl).attr("ng-src", coverImageUrl).css("box-shadow", "1px 1px 2px #ccc");
         }
+
+        if (!showOneLink() && (directToPDFUrl || articleLinkUrl)) {
+          const oneLinkElement = $(documentSummary).find(".availabilityContent");
+
+          if (oneLinkElement) {
+            oneLinkElement.remove();
+          }
+        }
       }
 
       if ((request.readyState == XMLHttpRequest.DONE && request.status == 404) || (isArticle(scope) && (!directToPDFUrl && !articleLinkUrl))) {
@@ -677,6 +685,14 @@ browzine.summon = (function() {
 
               if (template) {
                 $(documentSummary).find(".docFooter .row:eq(0)").prepend(template);
+              }
+
+              if (!showOneLink() && template) {
+                const oneLinkElement = $(documentSummary).find(".availabilityContent");
+
+                if (oneLinkElement) {
+                  oneLinkElement.remove();
+                }
               }
             }
           };

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -2048,6 +2048,89 @@ describe("BrowZine Primo Adapter >", function() {
         expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/articles/379795373/full-text-file", "_blank");
       });
     });
+
+    describe("search results article with onelink and both browzine web link and direct to pdf link >", function() {
+      beforeEach(function() {
+        primo = browzine.primo;
+        browzine.showPrimoOnlineAccessLink = false;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'><div class='layout-row'><span class='availability-status'>Available Online</span></div></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.$ctrl = {
+            parentCtrl: {
+              result: {
+                pnx: {
+                  display: {
+                    type: ["article"]
+                  },
+
+                  addata: {
+                    issn: ["0028-4793"],
+                    doi: ["10.1136/bmj.h2575"]
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$ctrl.parentCtrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 55134408,
+              "type": "articles",
+              "title": "New England Journal of Medicine reconsiders relationship with industry",
+              "date": "2015-05-12",
+              "authors": "McCarthy, M.",
+              "inPress": false,
+              "availableThroughBrowzine": true,
+              "startPage": "h2575",
+              "endPage": "h2575",
+              "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575",
+              "fullTextFile": "https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file"
+            },
+            "included": [{
+              "id": 18126,
+              "type": "journals",
+              "title": "theBMJ",
+              "issn": "09598138",
+              "sjrValue": 2.567,
+              "coverImageUrl": "https://assets.thirdiron.com/images/covers/0959-8138.png",
+              "browzineEnabled": true,
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
+            }]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1136%2Fbmj.h2575/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+        delete browzine.showPrimoOnlineAccessLink;
+      });
+
+      it("should not show the onelink option", function() {
+        expect(searchResult).toBeDefined();
+        expect(searchResult.text().trim()).toContain("Download PDF");
+        expect(searchResult.text().trim()).not.toContain("Available Online");
+      });
+    });
   });
 
   describe("search results without scope data >", function() {

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -1758,5 +1758,75 @@ describe("BrowZine Summon Adapter >", function() {
         expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/articles/379795373/full-text-file", "_blank");
       });
     });
+
+    describe("search results article with onelink and both browzine web link and direct to pdf link >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+        browzine.showSummonFullTextOnlineLink = false;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'><div class='availabilityContent'><span class='contentType'>Journal Article </span><a class='availabilityLink' href='#'>Full Text Online </a></div></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1136/bmj.h2575"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 55134408,
+              "type": "articles",
+              "title": "New England Journal of Medicine reconsiders relationship with industry",
+              "date": "2015-05-12",
+              "authors": "McCarthy, M.",
+              "inPress": false,
+              "availableThroughBrowzine": true,
+              "startPage": "h2575",
+              "endPage": "h2575",
+              "browzineWebLink": "https://browzine.com/libraries/XXX/journals/18126/issues/7764583?showArticleInContext=doi:10.1136/bmj.h2575",
+              "fullTextFile": "https://develop.browzine.com/libraries/XXX/articles/55134408/full-text-file"
+            },
+            "included": [{
+              "id": 18126,
+              "type": "journals",
+              "title": "theBMJ",
+              "issn": "09598138",
+              "sjrValue": 2.567,
+              "coverImageUrl": "https://assets.thirdiron.com/images/covers/0959-8138.png",
+              "browzineEnabled": true,
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
+            }]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1136%2Fbmj.h2575/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+        delete browzine.showSummonFullTextOnlineLink;
+      });
+
+      it("should not show the onelink option", function() {
+        expect(documentSummary).toBeDefined();
+        expect(documentSummary.text().trim()).toContain("Article PDF Download Now");
+        expect(documentSummary.text().trim()).not.toContain("Journal Article Full Text Online");
+      });
+    });
   });
 });

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -1602,6 +1602,30 @@ describe("Primo Model >", function() {
     });
   });
 
+  describe("primo model showOneLink method >", function() {
+    beforeEach(function() {
+      delete browzine.showPrimoOnlineAccessLink;
+    });
+
+    afterEach(function() {
+      delete browzine.showPrimoOnlineAccessLink;
+    });
+
+    it("should disable onelink when configuration property is undefined or null", function() {
+      expect(primo.showOneLink()).toEqual(true);
+    });
+
+    it("should disable onelink when configuration property is true", function() {
+      browzine.showPrimoOnlineAccessLink = true;
+      expect(primo.showOneLink()).toEqual(true);
+    });
+
+    it("should not disable onelink when configuration property is false", function() {
+      browzine.showPrimoOnlineAccessLink = false;
+      expect(primo.showOneLink()).toEqual(false);
+    });
+  });
+
   describe("primo model isFiltered method >", function() {
     beforeEach(function() {
       delete browzine.printRecordsIntegrationEnabled;

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -1156,6 +1156,30 @@ describe("Summon Model >", function() {
     });
   });
 
+  describe("summon model showOneLink method >", function() {
+    beforeEach(function() {
+      delete browzine.showSummonFullTextOnlineLink;
+    });
+
+    afterEach(function() {
+      delete browzine.showSummonFullTextOnlineLink;
+    });
+
+    it("should disable onelink when configuration property is undefined or null", function() {
+      expect(summon.showOneLink()).toEqual(true);
+    });
+
+    it("should disable onelink when configuration property is true", function() {
+      browzine.showSummonFullTextOnlineLink = true;
+      expect(summon.showOneLink()).toEqual(true);
+    });
+
+    it("should not disable onelink when configuration property is false", function() {
+      browzine.showSummonFullTextOnlineLink = false;
+      expect(summon.showOneLink()).toEqual(false);
+    });
+  });
+
   describe("summon model isFiltered method >", function() {
     beforeEach(function() {
       delete browzine.printRecordsIntegrationEnabled;


### PR DESCRIPTION
## Summary - [BZ-6736](https://thirdiron.atlassian.net/browse/BZ-6736)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Adds the ability to manage OneLink in Summon and Primo using a configuration property.

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

TODO:
- Add configuration properties (**DONE**)
- Implement hiding OneLink when enabled (**DONE**)
- Unit Tests (**DONE**)
- Acceptance Tests (**DONE**)


## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->


- None
