### PR TITLE
feature/libkey-onelink-should-not-be-enabled-by-default-BZ-6736

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 360-core-loader.js
 summon-loader.js
+oneLinkSummon.js

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -429,7 +429,7 @@ browzine.primo = (function() {
     var featureEnabled = false;
     var config = browzine.libKeyOneLinkView;
 
-    if (typeof config === "undefined" || config === null || config === true) {
+    if (config === true) {
       featureEnabled = true;
     }
 

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -417,7 +417,7 @@ browzine.summon = (function() {
     var featureEnabled = false;
     var config = browzine.libKeyOneLinkView;
 
-    if (typeof config === "undefined" || config === null || config === true) {
+    if (config === true) {
       featureEnabled = true;
     }
 

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -1682,14 +1682,14 @@ describe("Primo Model >", function() {
       delete browzine.libKeyOneLinkView;
     });
 
-    it("should enable onelink when configuration property is undefined", function() {
+    it("should not enable onelink when configuration property is undefined", function() {
       delete browzine.libKeyOneLinkView;
-      expect(primo.showLibKeyOneLinkView()).toEqual(true);
+      expect(primo.showLibKeyOneLinkView()).toEqual(false);
     });
 
-    it("should enable onelink when configuration property is null", function() {
+    it("should not enable onelink when configuration property is null", function() {
       browzine.libKeyOneLinkView = null;
-      expect(primo.showLibKeyOneLinkView()).toEqual(true);
+      expect(primo.showLibKeyOneLinkView()).toEqual(false);
     });
 
     it("should enable onelink when configuration property is true", function() {

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -1213,14 +1213,14 @@ describe("Summon Model >", function() {
       delete browzine.libKeyOneLinkView;
     });
 
-    it("should enable onelink when configuration property is undefined", function() {
+    it("should not enable onelink when configuration property is undefined", function() {
       delete browzine.libKeyOneLinkView;
-      expect(summon.showLibKeyOneLinkView()).toEqual(true);
+      expect(summon.showLibKeyOneLinkView()).toEqual(false);
     });
 
-    it("should enable onelink when configuration property is null", function() {
+    it("should not enable onelink when configuration property is null", function() {
       browzine.libKeyOneLinkView = null;
-      expect(summon.showLibKeyOneLinkView()).toEqual(true);
+      expect(summon.showLibKeyOneLinkView()).toEqual(false);
     });
 
     it("should enable onelink when configuration property is true", function() {


### PR DESCRIPTION
## Summary - [BZ-6736](https://thirdiron.atlassian.net/browse/BZ-6736)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

LibKey OneLink should not be enabled by default.


## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->


- None
