### PR TITLE
oneLink should default to off in both dec2021 update and otherwise - bz 6936

### DIFF
--- a/tests/unit/models/summon-dec2021Update.js
+++ b/tests/unit/models/summon-dec2021Update.js
@@ -1215,14 +1215,14 @@ describe("Summon Model with dec2021Update set to true (the non-default behavior 
       delete browzine.libKeyOneLinkView;
     });
 
-    it("should enable onelink when configuration property is undefined", function() {
+    it("should not enable onelink when configuration property is undefined", function() {
       delete browzine.libKeyOneLinkView;
-      expect(summon.showLibKeyOneLinkView()).toEqual(true);
+      expect(summon.showLibKeyOneLinkView()).toEqual(false);
     });
 
-    it("should enable onelink when configuration property is null", function() {
+    it("should not enable onelink when configuration property is null", function() {
       browzine.libKeyOneLinkView = null;
-      expect(summon.showLibKeyOneLinkView()).toEqual(true);
+      expect(summon.showLibKeyOneLinkView()).toEqual(false);
     });
 
     it("should enable onelink when configuration property is true", function() {


### PR DESCRIPTION
## Summary - [BZ-6936](https://thirdiron.atlassian.net/browse/BZ-6936)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Ensure tests pass related to default settings

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

Not a big change, just makes sure tests pass. 

I'll merge this once tests pass to get staging building again @tiandavis , but feel free to leave any comments if you think of anything.

Thanks!


## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None
