### PR TITLE
feature/retraction-watch-overrides-show-format-choice-BZ-7024

### DIFF
--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -744,7 +744,7 @@ browzine.primo = (function() {
           libKeyLinkOptimizer.innerHTML += template;
         }
 
-        if ((!directToPDFUrl || showFormatChoice()) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
+        if ((!directToPDFUrl || (showFormatChoice() && !articleRetractionUrl)) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
           var template = articleLinkTemplate(articleLinkUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -801,7 +801,7 @@ browzine.summon = (function() {
           libKeyLinkOptimizer.innerHTML += template;
         }
 
-        if ((!directToPDFUrl || showFormatChoice()) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
+        if ((!directToPDFUrl || (showFormatChoice() && !articleRetractionUrl)) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
           var template = articleLinkTemplate(articleLinkUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -544,6 +544,142 @@ describe("BrowZine Primo Adapter >", function() {
       });
     });
 
+    describe("search results article with both retracted article link and article link >", function() {
+      beforeEach(function() {
+        primo = browzine.primo;
+        browzine.showFormatChoice = true;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.$ctrl = {
+            parentCtrl: {
+              result: {
+                pnx: {
+                  display: {
+                    type: ["article"]
+                  },
+
+                  addata: {
+                    issn: ["0028-4793"],
+                    doi: ["10.1186/s11671-016-1523-5"]
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$ctrl.parentCtrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 59474947,
+              "type": "articles",
+              "title": "RETRACTED ARTICLE: Flexible Field Emitter for X-ray Generation by Implanting CNTs into Nickel Foil",
+              "date": "2016-07-11",
+              "authors": "Sun, Bin; Wang, Yan; Ding, Guifu",
+              "inPress": false,
+              "doi": "10.1186/s11671-016-1523-5",
+              "ILLURL": "https://illiad.mines.edu/illiad//illiad.dll?Action=10&Form=30&&rft.genre=article&rft.aulast=Sun&rft.issn=1931-7573&rft.jtitle=Nanoscale%20Research%20Letters&rft.atitle=RETRACTED%20ARTICLE%3A%20Flexible%20Field%20Emitter%20for%20X-ray%20Generation%20by%20Implanting%20CNTs%20into%20Nickel%20Foil&rft.volume=11&rft.issue=1&rft.spage=326&rft.epage=&rft.date=2016-07-11&rfr_id=BrowZine",
+              "pmid": "27401089",
+              "openAccess": true,
+              "fullTextFile": "https://develop.libkey.io/libraries/XXXX/articles/59474947/full-text-file?utm_source=api_716",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/59474947/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "326",
+              "endPage": "",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/8645/issues/8065238?showArticleInContext=doi:10.1186%2Fs11671-016-1523-5&utm_source=api_716",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 8645
+                  }
+                }
+              },
+              "retractionNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1186/s11671-016-1523-5"
+            },
+            "included": [
+              {
+                "id": 8645,
+                "type": "journals",
+                "title": "Nanoscale Research Letters",
+                "issn": "19317573",
+                "sjrValue": 0.782,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1931-7573.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/8645?utm_source=api_716"
+              }
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1186%2Fs11671-016-1523-5/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+        delete browzine.showFormatChoice;
+      });
+
+      it("should have an enhanced browse article in browzine option", function() {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).toContain("Retracted Article");
+        expect(template.text().trim()).not.toContain("Read Article");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/8645/issues/8065238?showArticleInContext=doi:10.1186%2Fs11671-016-1523-5&utm_source=api_716");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.svg");
+
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1186/s11671-016-1523-5");
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function(done) {
+        requestAnimationFrame(function() {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function(coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/1931-7573.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when a retracted article link is clicked", function() {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-direct-to-pdf-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1186/s11671-016-1523-5", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function() {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/8645/issues/8065238?showArticleInContext=doi:10.1186%2Fs11671-016-1523-5&utm_source=api_716", "_blank");
+      });
+    });
+
     describe("search results article with a journal issn but no article doi >", function() {
       beforeEach(function() {
         primo = browzine.primo;

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -636,7 +636,7 @@ describe("BrowZine Primo Adapter >", function() {
         delete browzine.showFormatChoice;
       });
 
-      it("should have an enhanced browse article in browzine option", function() {
+      it("should have an enhanced browse article showing retraction watch only", function() {
         var template = searchResult.find(".browzine");
 
         expect(template).toBeDefined();

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -349,6 +349,121 @@ describe("BrowZine Summon Adapter >", function() {
       });
     });
 
+    describe("search results article with both retracted article link and article link >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+        browzine.showFormatChoice = true;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1155/2019/5730746"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 284414450,
+              "type": "articles",
+              "title": "Operational Risk Assessment for International Transport Corridor: A Case Study of China-Pakistan Economic Corridor",
+              "date": "2019-03-04",
+              "authors": "Lei, Yang; Huang, Chengfeng; Wu, Yuan",
+              "inPress": false,
+              "doi": "10.1155/2019/5730746",
+              "ILLURL": "https://illiad.mines.edu/illiad//illiad.dll?Action=10&Form=30&&rft.genre=article&rft.aulast=Lei&rft.issn=1026-0226&rft.jtitle=Discrete%20Dynamics%20in%20Nature%20and%20Society&rft.atitle=Operational%20Risk%20Assessment%20for%20International%20Transport%20Corridor%3A%20A%20Case%20Study%20of%20China-Pakistan%20Economic%20Corridor&rft.volume=2019&rft.issue=&rft.spage=1&rft.epage=7&rft.date=2019-03-04&rfr_id=BrowZine",
+              "pmid": "",
+              "openAccess": true,
+              "fullTextFile": "https://develop.libkey.io/libraries/XXXX/articles/284414450/full-text-file?utm_source=api_716",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/284414450/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "1",
+              "endPage": "7",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/36603/issues/205373599?showArticleInContext=doi:10.1155%2F2019%2F5730746&utm_source=api_716",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 36603
+                  }
+                }
+              },
+              "retractionNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1155/2019/5730746"
+            },
+            "included": [
+              {
+                "id": 36603,
+                "type": "journals",
+                "title": "Discrete Dynamics in Nature and Society",
+                "issn": "10260226",
+                "sjrValue": 0.266,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1026-0226.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/36603?utm_source=api_716"
+              }
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1155%2F2019%2F5730746/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+        delete browzine.showFormatChoice;
+      });
+
+      it("should have an enhanced browse article showing retraction watch only", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View in Context Browse Journal");
+        expect(template.text().trim()).toContain("Retracted Article More Info");
+        expect(template.text().trim()).not.toContain("Article Page");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/36603/issues/205373599?showArticleInContext=doi:10.1155%2F2019%2F5730746&utm_source=api_716");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1155/2019/5730746");
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+        expect(template.find("svg.browzine-pdf-icon")).toBeDefined();
+      });
+
+      it("should have an enhanced browzine journal cover", function() {
+        var coverImage = documentSummary.find(".coverImage img");
+        expect(coverImage).toBeDefined();
+        expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/1026-0226.png");
+      });
+
+      it("should open a new window when a retracted article link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-direct-to-pdf-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1155/2019/5730746", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/36603/issues/205373599?showArticleInContext=doi:10.1155%2F2019%2F5730746&utm_source=api_716", "_blank");
+      });
+    });
+
     describe("search results article with a journal issn but no article doi >", function() {
       beforeEach(function() {
         summon = browzine.summon;


### PR DESCRIPTION
## Summary - [BZ-7024](https://thirdiron.atlassian.net/browse/BZ-7024)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Retraction Watch should override showFormatChoice.

## Description

TODO
- Adds failing test where retraction watch does not override showFormatChoice (**DONE**)
- Update implementation so retraction watch overrides showFormatChoice (**DONE**)

## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None
