### PR TITLE
feature/retraction-watch-enhancements-BZ-7023

### DIFF
--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -554,6 +554,30 @@ browzine.primo = (function() {
     return template;
   };
 
+  function retractionLinkTemplate(articleRetractionUrl) {
+    var articleLinkUrl = articleRetractionUrl;
+    var linkIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
+    var linkIconWidth = "15";
+    var linkIconMarginRight = "1.5px";
+    var articleLinkText = browzine.articleRetractionWatchText || "Retracted Article";
+
+    var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
+                      "<a class='browzine-article-link' href='{articleLinkUrl}' target='_blank' onclick='browzine.primo.transition(event, this)'>" +
+                          "<img alt='BrowZine Article Link Icon' src='{linkIcon}' class='browzine-article-link-icon' style='margin-bottom: -3px; margin-right: {linkIconMarginRight};' aria-hidden='true' width='{linkIconWidth}' height='16'/> " +
+                          "<span class='browzine-article-link-text'>{articleLinkText}</span> " +
+                          "<md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon>" +
+                      "</a>" +
+                   "</div>";
+
+    template = template.replace(/{articleLinkUrl}/g, articleLinkUrl);
+    template = template.replace(/{articleLinkText}/g, articleLinkText);
+    template = template.replace(/{linkIcon}/g, linkIcon);
+    template = template.replace(/{linkIconWidth}/g, linkIconWidth);
+    template = template.replace(/{linkIconMarginRight}/g, linkIconMarginRight);
+
+    return template;
+  };
+
   function browzineWebLinkTemplate(scope, browzineWebLink) {
     var browzineWebLinkText = "";
     var bookIcon = "https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.svg";
@@ -758,6 +782,11 @@ browzine.primo = (function() {
 
         if ((!directToPDFUrl || (showFormatChoice() && !articleRetractionUrl)) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
           var template = articleLinkTemplate(articleLinkUrl, articleRetractionUrl);
+          libKeyLinkOptimizer.innerHTML += template;
+        }
+
+        if (!directToPDFUrl && !articleLinkUrl && articleRetractionUrl && isArticle(scope) && showRetractionWatch()) {
+          var template = retractionLinkTemplate(articleRetractionUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -554,7 +554,7 @@ browzine.primo = (function() {
     return template;
   };
 
-  function retractionLinkTemplate(articleRetractionUrl) {
+  function retractionWatchLinkTemplate(articleRetractionUrl) {
     var articleLinkUrl = articleRetractionUrl;
     var linkIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
     var linkIconWidth = "15";
@@ -786,7 +786,7 @@ browzine.primo = (function() {
         }
 
         if (!directToPDFUrl && !articleLinkUrl && articleRetractionUrl && isArticle(scope) && showRetractionWatch()) {
-          var template = retractionLinkTemplate(articleRetractionUrl);
+          var template = retractionWatchLinkTemplate(articleRetractionUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 
@@ -975,6 +975,7 @@ browzine.primo = (function() {
     transition: transition,
     directToPDFTemplate: directToPDFTemplate,
     articleLinkTemplate: articleLinkTemplate,
+    retractionWatchLinkTemplate: retractionWatchLinkTemplate,
     browzineWebLinkTemplate: browzineWebLinkTemplate,
     unpaywallArticlePDFTemplate: unpaywallArticlePDFTemplate,
     unpaywallArticleLinkTemplate: unpaywallArticleLinkTemplate,

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -523,13 +523,23 @@ browzine.primo = (function() {
     return template;
   };
 
-  function articleLinkTemplate(articleLinkUrl) {
+  function articleLinkTemplate(articleLinkUrl, articleRetractionUrl) {
     var linkIcon = "https://assets.thirdiron.com/images/integrations/browzine-article-link-icon.svg";
+    var linkIconWidth = "12";
+    var linkIconMarginRight = "4.5px";
     var articleLinkText = browzine.articleLinkText  || "Read Article";
+
+    if (showRetractionWatchUI(articleRetractionUrl)) {
+      articleLinkUrl = articleRetractionUrl;
+      linkIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
+      linkIconWidth = "15";
+      linkIconMarginRight = "1.5px";
+      articleLinkText = browzine.articleRetractionWatchText || "Retracted Article";
+    }
 
     var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
                       "<a class='browzine-article-link' href='{articleLinkUrl}' target='_blank' onclick='browzine.primo.transition(event, this)'>" +
-                          "<img alt='BrowZine Article Link Icon' src='{linkIcon}' class='browzine-article-link-icon' style='margin-bottom: -3px; margin-right: 4.5px;' aria-hidden='true' width='12' height='16'/> " +
+                          "<img alt='BrowZine Article Link Icon' src='{linkIcon}' class='browzine-article-link-icon' style='margin-bottom: -3px; margin-right: {linkIconMarginRight};' aria-hidden='true' width='{linkIconWidth}' height='16'/> " +
                           "<span class='browzine-article-link-text'>{articleLinkText}</span> " +
                           "<md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon>" +
                       "</a>" +
@@ -538,6 +548,8 @@ browzine.primo = (function() {
     template = template.replace(/{articleLinkUrl}/g, articleLinkUrl);
     template = template.replace(/{articleLinkText}/g, articleLinkText);
     template = template.replace(/{linkIcon}/g, linkIcon);
+    template = template.replace(/{linkIconWidth}/g, linkIconWidth);
+    template = template.replace(/{linkIconMarginRight}/g, linkIconMarginRight);
 
     return template;
   };
@@ -745,7 +757,7 @@ browzine.primo = (function() {
         }
 
         if ((!directToPDFUrl || (showFormatChoice() && !articleRetractionUrl)) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
-          var template = articleLinkTemplate(articleLinkUrl);
+          var template = articleLinkTemplate(articleLinkUrl, articleRetractionUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -573,7 +573,7 @@ browzine.summon = (function() {
     return template;
   };
 
-  function retractionLinkTemplate(articleRetractionUrl) {
+  function retractionWatchLinkTemplate(articleRetractionUrl) {
     var articleLinkUrl = articleRetractionUrl;
     var paperIcon = getRetractionWatchIconSvg();
 
@@ -840,7 +840,7 @@ browzine.summon = (function() {
         }
 
         if (!directToPDFUrl && !articleLinkUrl && articleRetractionUrl && isArticle(scope) && showRetractionWatch()) {
-          var template = retractionLinkTemplate(articleRetractionUrl);
+          var template = retractionWatchLinkTemplate(articleRetractionUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 
@@ -1004,6 +1004,7 @@ browzine.summon = (function() {
     browzineWebLinkTemplate: browzineWebLinkTemplate,
     directToPDFTemplate: directToPDFTemplate,
     articleLinkTemplate: articleLinkTemplate,
+    retractionWatchLinkTemplate: retractionWatchLinkTemplate,
     unpaywallArticlePDFTemplate: unpaywallArticlePDFTemplate,
     unpaywallArticleLinkTemplate: unpaywallArticleLinkTemplate,
     unpaywallManuscriptPDFTemplate: unpaywallManuscriptPDFTemplate,

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -573,6 +573,31 @@ browzine.summon = (function() {
     return template;
   };
 
+  function retractionLinkTemplate(articleRetractionUrl) {
+    var articleLinkUrl = articleRetractionUrl;
+    var paperIcon = getRetractionWatchIconSvg();
+
+    var articleLinkTextWording = "Retracted Article";
+    var articleLinkText = "More Info";
+
+    if (+browzine.version >= 2) {
+      articleLinkTextWording = browzine.articleRetractionWatchTextWording || articleLinkTextWording;
+      articleLinkText = browzine.articleRetractionWatchText || articleLinkText;
+    }
+
+    var template = "<div class='browzine'>" +
+      "<span class='contentType' style='margin-right: 4.5px;'>{articleLinkTextWording}</span>" +
+      "<a class='browzine-article-link summonBtn customPrimaryLink' href='{articleLinkUrl}' target='_blank' onclick='browzine.summon.transition(event, this)'>{paperIcon}<span style='margin-left: 0px;'>{articleLinkText}</span></a>" +
+    "</div>";
+
+    template = template.replace(/{articleLinkTextWording}/g, articleLinkTextWording);
+    template = template.replace(/{articleLinkUrl}/g, articleLinkUrl);
+    template = template.replace(/{articleLinkText}/g, articleLinkText);
+    template = template.replace(/{paperIcon}/g, paperIcon);
+
+    return template;
+  };
+
   function browzineWebLinkTemplate(scope, browzineWebLink) {
     var wording = "";
     var browzineWebLinkText = "";
@@ -811,6 +836,11 @@ browzine.summon = (function() {
 
         if ((!directToPDFUrl || (showFormatChoice() && !articleRetractionUrl)) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
           var template = articleLinkTemplate(articleLinkUrl, articleRetractionUrl);
+          libKeyLinkOptimizer.innerHTML += template;
+        }
+
+        if (!directToPDFUrl && !articleLinkUrl && articleRetractionUrl && isArticle(scope) && showRetractionWatch()) {
+          var template = retractionLinkTemplate(articleRetractionUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -542,7 +542,7 @@ browzine.summon = (function() {
     return template;
   };
 
-  function articleLinkTemplate(articleLinkUrl) {
+  function articleLinkTemplate(articleLinkUrl, articleRetractionUrl) {
     var paperIcon = getPaperIconSvg();
 
     var articleLinkTextWording = "View Now";
@@ -553,8 +553,16 @@ browzine.summon = (function() {
       articleLinkText = browzine.articleLinkText || articleLinkText;
     }
 
+    if (showRetractionWatchUI(articleRetractionUrl)) {
+      articleLinkUrl = articleRetractionUrl;
+      paperIcon = getRetractionWatchIconSvg();
+      articleLinkTextWording = browzine.articleRetractionWatchTextWording || "Retracted Article";
+      articleLinkText = browzine.articleRetractionWatchText || "More Info";
+    }
+
     var template = "<div class='browzine'>" +
-      "<span class='contentType' style='margin-right: 4.5px;'>{articleLinkTextWording}</span><a class='browzine-article-link summonBtn customPrimaryLink' href='{articleLinkUrl}' target='_blank' onclick='browzine.summon.transition(event, this)'>{paperIcon}<span style='margin-left: 0px;'>{articleLinkText}</span></a>" +
+      "<span class='contentType' style='margin-right: 4.5px;'>{articleLinkTextWording}</span>" +
+      "<a class='browzine-article-link summonBtn customPrimaryLink' href='{articleLinkUrl}' target='_blank' onclick='browzine.summon.transition(event, this)'>{paperIcon}<span style='margin-left: 0px;'>{articleLinkText}</span></a>" +
     "</div>";
 
     template = template.replace(/{articleLinkTextWording}/g, articleLinkTextWording);
@@ -802,7 +810,7 @@ browzine.summon = (function() {
         }
 
         if ((!directToPDFUrl || (showFormatChoice() && !articleRetractionUrl)) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
-          var template = articleLinkTemplate(articleLinkUrl);
+          var template = articleLinkTemplate(articleLinkUrl, articleRetractionUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -682,6 +682,132 @@ describe("BrowZine Primo Adapter >", function() {
       });
     });
 
+    describe("retraction notice and no pdf link or article link >", function() {
+      beforeEach(function() {
+        primo = browzine.primo;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.$ctrl = {
+            parentCtrl: {
+              result: {
+                pnx: {
+                  display: {
+                    type: ["article"]
+                  },
+
+                  addata: {
+                    issn: ["0898929X"],
+                    doi: ["10.1162/jocn_a_00867"]
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$ctrl.parentCtrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 56171427,
+              "type": "articles",
+              "title": "Effects of Transcranial Direct Current Stimulation over Left Dorsolateral pFC on the Attentional Blink Depend on Individual Baseline Performance",
+              "date": "2015-12-01",
+              "authors": "London, Raquel E.; Slagter, Heleen A.",
+              "inPress": false,
+              "doi": "10.1162/jocn_a_00867",
+              "ILLURL": "",
+              "pmid": "26284996",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "",
+              "availableThroughBrowzine": false,
+              "startPage": "2382",
+              "endPage": "2393",
+              "relationships": {
+                "library": {
+                  "data": {
+                    "type": "libraries",
+                    "id": 1466
+                  }
+                }
+              },
+              "retractionNoticeUrl": "https://libkey.io/libraries/1466/10.1162/jocn_a_00867"
+            },
+            "included": [
+              {
+                "id": 32127,
+                "type": "journals",
+                "title": "Journal of Cognitive Neuroscience",
+                "issn": "0898929X",
+                "sjrValue": 2.132,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/0898-929X.png",
+                "browzineEnabled": false,
+                "externalLink": "https://bibsys-almaprimo.hosted.exlibrisgroup.com/primo-explore/search?query=issn,exact,0898-929X,OR&query=issn,exact,,AND&pfilter=pfilter,exact,journals,AND&tab=default_tab&search_scope=default_scope&sortby=rank&vid=UBIN&lang=no_NO&mode=advanced&offset=0"
+              },
+              {
+                "id": 1466,
+                "type": "libraries",
+                "discoveryServiceBehavior": "classic"
+              }
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1162%2Fjocn_a_00867/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show retraction notices when available even if no pdf link or article link available", function() {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("Retracted Article");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://libkey.io/libraries/1466/10.1162/jocn_a_00867");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-article-link-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function(done) {
+        requestAnimationFrame(function() {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function(coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/0898-929X.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when a retracted article link is clicked", function() {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://libkey.io/libraries/1466/10.1162/jocn_a_00867", "_blank");
+      });
+    });
+
     describe("search results article with both retracted article link and article link >", function() {
       beforeEach(function() {
         primo = browzine.primo;

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -544,6 +544,144 @@ describe("BrowZine Primo Adapter >", function() {
       });
     });
 
+    describe("retraction notice and only an article link >", function() {
+      beforeEach(function() {
+        primo = browzine.primo;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.$ctrl = {
+            parentCtrl: {
+              result: {
+                pnx: {
+                  display: {
+                    type: ["article"]
+                  },
+
+                  addata: {
+                    issn: ["0898929X"],
+                    doi: ["10.1162/jocn_a_00867"]
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$ctrl.parentCtrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 56171427,
+              "type": "articles",
+              "title": "Effects of Transcranial Direct Current Stimulation over Left Dorsolateral pFC on the Attentional Blink Depend on Individual Baseline Performance",
+              "date": "2015-12-01",
+              "authors": "London, Raquel E.; Slagter, Heleen A.",
+              "inPress": false,
+              "doi": "10.1162/jocn_a_00867",
+              "ILLURL": "https://sfu-primo.hosted.exlibrisgroup.com/primo-explore/openurl?ctx_ver=Z39.88-2004&rft.genre=article&ctx_enc=info:ofi%2Fenc:UTF-8&url_ver=Z39.88-2004&url_ctx_fmt=infofi%2Ffmt:kev:mtx:ctx&url_ctx_fmt=infofi%2Ffmt:kev:mtx:ctx&rfr_id=info:sid%2Fprimo.exlibrisgroup.com:primo4-article-cLinker&rft_val_fmt=info:ofi%2Ffmt:kev:mtx:article&rft.aulast=London&rft.issn=0898-929X&rft.jtitle=Journal%20of%20Cognitive%20Neuroscience&rft.atitle=Effects%20of%20Transcranial%20Direct%20Current%20Stimulation%20over%20Left%20Dorsolateral%20pFC%20on%20the%20Attentional%20Blink%20Depend%20on%20Individual%20Baseline%20Performance&rft.volume=27&rft.issue=12&rft.spage=2382&rft.epage=2393&rft.date=2015-12-01&rft.doi=10.1162%2Fjocn_a_00867&vid=SFUL&institution=01SFUL&url_ctx_val=&isSerivcesPage=true",
+              "pmid": "26284996",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "https://libkey.io/libraries/513/articles/56171427/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://browzine.com/libraries/513/journals/32127/issues/7986254?showArticleInContext=doi:10.1162%2Fjocn_a_00867&utm_source=api_572",
+              "relationships": {
+                "library": {
+                  "data": {
+                    "type": "libraries",
+                    "id": 513
+                  }
+                }
+              },
+              "retractionNoticeUrl": "https://libkey.io/libraries/513/10.1162/jocn_a_00867"
+            },
+            "included": [
+              {
+                "id": 32127,
+                "type": "journals",
+                "title": "Journal of Cognitive Neuroscience",
+                "issn": "0898929X",
+                "sjrValue": 2.132,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/0898-929X.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://browzine.com/libraries/513/journals/32127?utm_source=api_572"
+              },
+              {
+                "id": 513,
+                "type": "libraries",
+                "discoveryServiceBehavior": "classic"
+              }
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1162%2Fjocn_a_00867/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show retraction notices when there is only an article link", function() {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).toContain("Retracted Article");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/513/journals/32127/issues/7986254?showArticleInContext=doi:10.1162%2Fjocn_a_00867&utm_source=api_572");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.svg");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://libkey.io/libraries/513/10.1162/jocn_a_00867");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-article-link-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function(done) {
+        requestAnimationFrame(function() {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function(coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/0898-929X.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when a retracted article link is clicked", function() {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://libkey.io/libraries/513/10.1162/jocn_a_00867", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function() {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://browzine.com/libraries/513/journals/32127/issues/7986254?showArticleInContext=doi:10.1162%2Fjocn_a_00867&utm_source=api_572", "_blank");
+      });
+    });
+
     describe("search results article with both retracted article link and article link >", function() {
       beforeEach(function() {
         primo = browzine.primo;

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -465,6 +465,111 @@ describe("BrowZine Summon Adapter >", function() {
       });
     });
 
+    describe("retraction notice and no pdf link or article link >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1162/jocn_a_00867"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 56171427,
+              "type": "articles",
+              "title": "Effects of Transcranial Direct Current Stimulation over Left Dorsolateral pFC on the Attentional Blink Depend on Individual Baseline Performance",
+              "date": "2015-12-01",
+              "authors": "London, Raquel E.; Slagter, Heleen A.",
+              "inPress": false,
+              "doi": "10.1162/jocn_a_00867",
+              "ILLURL": "",
+              "pmid": "26284996",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "",
+              "availableThroughBrowzine": false,
+              "startPage": "2382",
+              "endPage": "2393",
+              "relationships": {
+                "library": {
+                  "data": {
+                    "type": "libraries",
+                    "id": 1466
+                  }
+                }
+              },
+              "retractionNoticeUrl": "https://libkey.io/libraries/1466/10.1162/jocn_a_00867"
+            },
+            "included": [
+              {
+                "id": 32127,
+                "type": "journals",
+                "title": "Journal of Cognitive Neuroscience",
+                "issn": "0898929X",
+                "sjrValue": 2.132,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/0898-929X.png",
+                "browzineEnabled": false,
+                "externalLink": "https://bibsys-almaprimo.hosted.exlibrisgroup.com/primo-explore/search?query=issn,exact,0898-929X,OR&query=issn,exact,,AND&pfilter=pfilter,exact,journals,AND&tab=default_tab&search_scope=default_scope&sortby=rank&vid=UBIN&lang=no_NO&mode=advanced&offset=0"
+              },
+              {
+                "id": 1466,
+                "type": "libraries",
+                "discoveryServiceBehavior": "classic"
+              }
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1162%2Fjocn_a_00867/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show retraction notices when available even if no pdf link or article link available", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("Retracted Article More Info");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://libkey.io/libraries/1466/10.1162/jocn_a_00867");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+      });
+
+      it("should have an enhanced browzine journal cover", function() {
+        var coverImage = documentSummary.find(".coverImage img");
+        expect(coverImage).toBeDefined();
+        expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0898-929X.png");
+      });
+
+      it("should open a new window when a retracted article link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://libkey.io/libraries/1466/10.1162/jocn_a_00867", "_blank");
+      });
+    });
+
     describe("search results article with both retracted article link and article link >", function() {
       beforeEach(function() {
         summon = browzine.summon;

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -349,6 +349,122 @@ describe("BrowZine Summon Adapter >", function() {
       });
     });
 
+    describe("retraction notice and only an article link >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1162/jocn_a_00867"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 56171427,
+              "type": "articles",
+              "title": "Effects of Transcranial Direct Current Stimulation over Left Dorsolateral pFC on the Attentional Blink Depend on Individual Baseline Performance",
+              "date": "2015-12-01",
+              "authors": "London, Raquel E.; Slagter, Heleen A.",
+              "inPress": false,
+              "doi": "10.1162/jocn_a_00867",
+              "ILLURL": "https://sfu-primo.hosted.exlibrisgroup.com/primo-explore/openurl?ctx_ver=Z39.88-2004&rft.genre=article&ctx_enc=info:ofi%2Fenc:UTF-8&url_ver=Z39.88-2004&url_ctx_fmt=infofi%2Ffmt:kev:mtx:ctx&url_ctx_fmt=infofi%2Ffmt:kev:mtx:ctx&rfr_id=info:sid%2Fprimo.exlibrisgroup.com:primo4-article-cLinker&rft_val_fmt=info:ofi%2Ffmt:kev:mtx:article&rft.aulast=London&rft.issn=0898-929X&rft.jtitle=Journal%20of%20Cognitive%20Neuroscience&rft.atitle=Effects%20of%20Transcranial%20Direct%20Current%20Stimulation%20over%20Left%20Dorsolateral%20pFC%20on%20the%20Attentional%20Blink%20Depend%20on%20Individual%20Baseline%20Performance&rft.volume=27&rft.issue=12&rft.spage=2382&rft.epage=2393&rft.date=2015-12-01&rft.doi=10.1162%2Fjocn_a_00867&vid=SFUL&institution=01SFUL&url_ctx_val=&isSerivcesPage=true",
+              "pmid": "26284996",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "https://libkey.io/libraries/513/articles/56171427/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://browzine.com/libraries/513/journals/32127/issues/7986254?showArticleInContext=doi:10.1162%2Fjocn_a_00867&utm_source=api_572",
+              "relationships": {
+                "library": {
+                  "data": {
+                    "type": "libraries",
+                    "id": 513
+                  }
+                }
+              },
+              "retractionNoticeUrl": "https://libkey.io/libraries/513/10.1162/jocn_a_00867"
+            },
+            "included": [
+              {
+                "id": 32127,
+                "type": "journals",
+                "title": "Journal of Cognitive Neuroscience",
+                "issn": "0898929X",
+                "sjrValue": 2.132,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/0898-929X.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://browzine.com/libraries/513/journals/32127?utm_source=api_572"
+              },
+              {
+                "id": 513,
+                "type": "libraries",
+                "discoveryServiceBehavior": "classic"
+              }
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1162%2Fjocn_a_00867/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show retraction notices when there is only an article link", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View in Context Browse Journal");
+        expect(template.text().trim()).toContain("Retracted Article More Info");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/513/journals/32127/issues/7986254?showArticleInContext=doi:10.1162%2Fjocn_a_00867&utm_source=api_572");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://libkey.io/libraries/513/10.1162/jocn_a_00867");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+      });
+
+      it("should have an enhanced browzine journal cover", function() {
+        var coverImage = documentSummary.find(".coverImage img");
+        expect(coverImage).toBeDefined();
+        expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0898-929X.png");
+      });
+
+      it("should open a new window when a retracted article link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://libkey.io/libraries/513/10.1162/jocn_a_00867", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://browzine.com/libraries/513/journals/32127/issues/7986254?showArticleInContext=doi:10.1162%2Fjocn_a_00867&utm_source=api_572", "_blank");
+      });
+    });
+
     describe("search results article with both retracted article link and article link >", function() {
       beforeEach(function() {
         summon = browzine.summon;

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -2088,6 +2088,75 @@ describe("Primo Model >", function() {
     });
   });
 
+  describe("primo model retractionWatchLinkTemplate method >", function() {
+    beforeEach(function() {
+      delete browzine.articleRetractionWatchEnabled;
+      delete browzine.articleRetractionWatchText;
+    });
+
+    afterEach(function() {
+      delete browzine.articleRetractionWatchEnabled;
+      delete browzine.articleRetractionWatchText;
+    });
+
+    it("should build a retraction watch template for article search results", function() {
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["article"]
+            },
+
+            addata: {
+              issn: ["0028-4793"],
+              doi: ["10.1136/bmj.h2575"]
+            }
+          }
+        }
+      };
+
+      var data = primo.getData(articleResponse);
+      var articleRetractionUrl = primo.getArticleRetractionUrl(scope, data);
+      var template = primo.retractionWatchLinkTemplate(articleRetractionUrl);
+
+      expect(data).toBeDefined();
+      expect(articleRetractionUrl).toBeDefined();
+
+      expect(template).toBeDefined();
+
+      expect(template).toEqual("<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'><a class='browzine-article-link' href='https://develop.libkey.io/libraries/1252/10.1155/2019/5730746' target='_blank' onclick='browzine.primo.transition(event, this)'><img alt='BrowZine Article Link Icon' src='https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg' class='browzine-article-link-icon' style='margin-bottom: -3px; margin-right: 1.5px;' aria-hidden='true' width='15' height='16'/> <span class='browzine-article-link-text'>Retracted Article</span> <md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon></a></div>");
+
+      expect(template).toContain("Retracted Article");
+      expect(template).toContain("https://develop.libkey.io/libraries/1252/10.1155/2019/5730746");
+      expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+    });
+
+    it("should apply the articleRetractionWatchText config property", function() {
+      browzine.articleRetractionWatchText = "Retracted Article (DO NOT REFERENCE)";
+
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["article"]
+            },
+
+            addata: {
+              issn: ["0028-4793"],
+              doi: ["10.1136/bmj.h2575"]
+            }
+          }
+        }
+      };
+
+      var data = primo.getData(articleResponse);
+      var articleRetractionUrl = primo.getArticleRetractionUrl(scope, data);
+      var template = primo.retractionWatchLinkTemplate(articleRetractionUrl);
+
+      expect(template).toContain("Retracted Article (DO NOT REFERENCE)");
+    });
+  });
+
   describe("primo model browzineWebLinkTemplate method >", function() {
     it("should build an enhancement template for journal search results", function() {
       var scope = {

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -1718,6 +1718,133 @@ describe("Summon Model >", function() {
     });
   });
 
+  describe("summon model retractionWatchLinkTemplate method >", function() {
+    beforeEach(function() {
+      delete browzine.articleRetractionWatchEnabled;
+      delete browzine.articleRetractionWatchTextWording;
+      delete browzine.articleRetractionWatchText;
+      delete browzine.version;
+    });
+
+    afterEach(function() {
+      delete browzine.articleRetractionWatchEnabled;
+      delete browzine.articleRetractionWatchTextWording;
+      delete browzine.articleRetractionWatchText;
+      delete browzine.version;
+    });
+
+    it("should build a retraction watch link template for article search results", function() {
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
+      var data = summon.getData(articleResponse);
+      var articleRetractionUrl = summon.getArticleRetractionUrl(scope, data);
+      var template = summon.retractionWatchLinkTemplate(articleRetractionUrl);
+
+      var $template = document.createElement("div");
+      $template.innerHTML = template;
+
+      expect(data).toBeDefined();
+      expect(articleRetractionUrl).toBeDefined();
+
+      expect(template).toBeDefined();
+
+      expect(template).toContain("https://develop.libkey.io/libraries/1252/10.1155/2019/5730746");
+
+      expect($template.innerText).toContain("Retracted Article More Info");
+    });
+
+    it("should apply the articleRetractionWatchTextWording config property", function() {
+      browzine.version = 2;
+      browzine.articleRetractionWatchTextWording = "Retracted Article (DO NOT REFERENCE)";
+
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
+      var data = summon.getData(articleResponse);
+      var articleRetractionUrl = summon.getArticleRetractionUrl(scope, data);
+      var template = summon.retractionWatchLinkTemplate(articleRetractionUrl);
+
+      var $template = document.createElement("div");
+      $template.innerHTML = template;
+
+      expect($template.innerText).toContain("Retracted Article (DO NOT REFERENCE)");
+    });
+
+    it("should apply the articleRetractionWatchText config property", function() {
+      browzine.version = "2";
+      browzine.articleRetractionWatchText = "Learn More";
+
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
+      var data = summon.getData(articleResponse);
+      var articleRetractionUrl = summon.getArticleRetractionUrl(scope, data);
+      var template = summon.retractionWatchLinkTemplate(articleRetractionUrl);
+
+      var $template = document.createElement("div");
+      $template.innerHTML = template;
+
+      expect($template.innerText).toContain("Retracted Article Learn More");
+    });
+
+    it("should not apply the articleRetractionWatchTextWording config property", function() {
+      delete browzine.version;
+      browzine.articleLinkTextWording = "Retracted Article (DO NOT REFERENCE)";
+
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
+      var data = summon.getData(articleResponse);
+      var articleRetractionUrl = summon.getArticleRetractionUrl(scope, data);
+      var template = summon.retractionWatchLinkTemplate(articleRetractionUrl);
+
+      var $template = document.createElement("div");
+      $template.innerHTML = template;
+
+      expect($template.innerText).toContain("Retracted Article More Info");
+      expect($template.innerText).not.toContain("Retracted Article (DO NOT REFERENCE)");
+    });
+
+    it("should not apply the articleRetractionWatchText config property", function() {
+      delete browzine.version;
+      browzine.articleRetractionWatchText = "Learn More";
+
+      var scope = {
+        document: {
+          content_type: "Journal Article",
+          dois: ["10.1136/bmj.h2575"]
+        }
+      };
+
+      var data = summon.getData(articleResponse);
+      var articleRetractionUrl = summon.getArticleRetractionUrl(scope, data);
+      var template = summon.retractionWatchLinkTemplate(articleRetractionUrl);
+
+      var $template = document.createElement("div");
+      $template.innerHTML = template;
+
+      expect($template.innerText).toContain("Retracted Article More Info");
+      expect($template.innerText).not.toContain("Learn More");
+    });
+  });
+
   describe("summon model browzineWebLinkTemplate method >", function() {
     it("should build a browzine web link template for journal search results", function() {
       var scope = {


### PR DESCRIPTION
## Summary - [BZ-7023](https://thirdiron.atlassian.net/browse/BZ-7023)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Retraction notices should be shown in discovery systems when there’s only an article link. Retraction notices should be shown in discovery systems when there is Unpaywall data. Retraction notices should be shown in discovery systems, even if something is not within a library’s holdings.


## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

TODO:
- Retraction notices should be shown in discovery systems when there’s only an article link (**DONE**)
- Retraction notices should be shown in discovery systems when there is Unpaywall data. (**CUSTOMER HAS OLD, SELF-HOSTED, HEAVILY CUSTOMIZED PRIMO ADAPTER**)
- Retraction notices should be shown in discovery systems, even if something is not within a library’s holdings. (**DONE**) 
  - Karl referenced this as a feature enhancement in https://thirdiron.atlassian.net/browse/BZ-7036


## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None
