### PR TITLE
Automatically run Release Notes Generator (renogen) to create a Deployment PR for every merge to develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,10 +147,11 @@ jobs:
     steps:
       - add_ssh_keys
       - run:
+          name: create ssh directory
+          command: mkdir ~/.ssh/
+      - run:
           name: add github.com to known_hosts
-          command: >
-            mkdir ~/.ssh/
-            ssh-keyscan github.com >> ~/.ssh/known_hosts
+          command: ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run:
           name: Clone release_notes_generator repository
           command: git clone git@github.com:thirdiron/release_notes_generator.git .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,11 +192,12 @@ workflows:
             branches:
               only: master
       - renogen:
-           requires:
-             - deploy-develop
+          #  requires:
+          #    - deploy-develop
            filters:
              branches:
                only:
+                 - feature/run-renogen-on-merge-to-develop
                  - develop
 
 experimental:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,12 +195,11 @@ workflows:
             branches:
               only: master
       - renogen:
-          #  requires:
-          #    - deploy-develop
+           requires:
+             - deploy-develop
            filters:
              branches:
                only:
-                 - feature/run-renogen-on-merge-to-develop
                  - develop
 
 experimental:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,25 +142,27 @@ jobs:
             . ~/.nvm/nvm.sh
             npm run deploy-primo-master
   renogen:
-     docker:
-       - image: cimg/node:12.18
-     steps:
-       - add_ssh_keys
-       - run:
-           name: add github.com to known_hosts
-           command: ssh-keyscan github.com >> ~/.ssh/known_hosts
-       - run:
-           name: Clone release_notes_generator repository
-           command: git clone git@github.com:thirdiron/release_notes_generator.git .
-       - run:
-           name: Install release_notes_generator dependencies
-           command: npm ci
-       - run:
-           name: Build release_notes_generator
-           command: npm run build
-       - run:
-           name: Generate release notes
-           command: npm run start -- browzine-discovery-service-adapters
+    docker:
+      - image: cimg/node:12.18
+    steps:
+      - add_ssh_keys
+      - run:
+          name: add github.com to known_hosts
+          command: >
+            mkdir ~/.ssh/
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - run:
+          name: Clone release_notes_generator repository
+          command: git clone git@github.com:thirdiron/release_notes_generator.git .
+      - run:
+          name: Install release_notes_generator dependencies
+          command: npm ci
+      - run:
+          name: Build release_notes_generator
+          command: npm run build
+      - run:
+          name: Generate release notes
+          command: npm run start -- browzine-discovery-service-adapters
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,26 @@ jobs:
           command: |
             . ~/.nvm/nvm.sh
             npm run deploy-primo-master
+  renogen:
+     docker:
+       - image: cimg/node:12.18
+     steps:
+       - add_ssh_keys
+       - run:
+           name: add github.com to known_hosts
+           command: ssh-keyscan github.com >> ~/.ssh/known_hosts
+       - run:
+           name: Clone release_notes_generator repository
+           command: git clone git@github.com:thirdiron/release_notes_generator.git .
+       - run:
+           name: Install release_notes_generator dependencies
+           command: npm ci
+       - run:
+           name: Build release_notes_generator
+           command: npm run build
+       - run:
+           name: Generate release notes
+           command: npm run start -- browzine-discovery-service-adapters
 
 workflows:
   version: 2
@@ -171,6 +191,13 @@ workflows:
           filters:
             branches:
               only: master
+      - renogen:
+           requires:
+             - deploy-develop
+           filters:
+             branches:
+               only:
+                 - develop
 
 experimental:
   notify:


### PR DESCRIPTION
## Summary - [BZ-XXXX](https://thirdiron.atlassian.net/browse/BZ-XXXX)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Create a deployment PR each time a merge to develop happens

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

Same as the changes in https://github.com/thirdiron/bz_holdings_importer/pull/123 , based on changes @johnmuth did in a few other repos including https://github.com/thirdiron/analytics-intake-server/pull/89

I had to make a little tweak, since a `~/.ssh/` directory didn't exist in this container right away. I added a line to create that directory.

https://github.com/thirdiron/browzine-discovery-service-adapters/pull/113 was created by the change in this PR, so the two things needed to be added to CircleCI seem to be working:
1. env var for GitHub access
2. the GitHub token for CircleCI for this repo to access release notes generator

## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None
