### PR TITLE
feature/primo-angular-v1.8-upgrade-BZ-7188

### DIFF
--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -739,7 +739,7 @@ browzine.primo = (function() {
   };
 
   function getScope($scope) {
-    return $scope && $scope.$ctrl && $scope.$ctrl.parentCtrl ? $scope.$ctrl.parentCtrl : undefined;
+    return $scope && $scope.$parent && $scope.$parent.$ctrl ? $scope.$parent.$ctrl : undefined;
   };
 
   function shouldEnhance(scope) {

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -428,17 +428,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1186/s11671-016-1523-5"]
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1186/s11671-016-1523-5"]
+                    }
                   }
                 }
               }
@@ -448,7 +450,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -561,17 +563,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0898929X"],
-                    doi: ["10.1162/jocn_a_00867"]
+                    addata: {
+                      issn: ["0898929X"],
+                      doi: ["10.1162/jocn_a_00867"]
+                    }
                   }
                 }
               }
@@ -581,7 +585,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -699,17 +703,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0898929X"],
-                    doi: ["10.1162/jocn_a_00867"]
+                    addata: {
+                      issn: ["0898929X"],
+                      doi: ["10.1162/jocn_a_00867"]
+                    }
                   }
                 }
               }
@@ -719,7 +725,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -826,17 +832,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1186/s11671-016-1523-5"]
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1186/s11671-016-1523-5"]
+                    }
                   }
                 }
               }
@@ -846,7 +854,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -1,5 +1,5 @@
 describe("BrowZine Primo Adapter >", function() {
-  var primo = {}, searchResult = {};
+  var primo = {}, searchResult = {}, $scope = {};
 
   $("body").append("<prm-search-result-list><div class='results-container'></div></prm-search-result-list>");
 
@@ -13,16 +13,18 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["journal"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["journal"]
+                    },
 
-                  addata: {
-                    issn: ["0096-6762", "0028-4793"]
+                    addata: {
+                      issn: ["0096-6762", "0028-4793"]
+                    }
                   }
                 }
               }
@@ -32,7 +34,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -108,21 +110,23 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["journal"]
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["journal"]
+                    },
+
+                    addata: {
+                      issn: ["0096-6762", "0028-4793"]
+                    }
                   },
 
-                  addata: {
-                    issn: ["0096-6762", "0028-4793"]
+                  delivery: {
+                    deliveryCategory: ["Alma-P"]
                   }
-                },
-
-                delivery: {
-                  deliveryCategory: ["Alma-P"]
                 }
               }
             }
@@ -131,7 +135,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -210,16 +214,18 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["journals"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["journals"]
+                    },
 
-                  addata: {
-                    issn: ["0096-6762", "0028-4793"]
+                    addata: {
+                      issn: ["0096-6762", "0028-4793"]
+                    }
                   }
                 }
               }
@@ -229,7 +235,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -303,17 +309,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1136/bmj.h2575"]
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1136/bmj.h2575"]
+                    }
                   }
                 }
               }
@@ -323,7 +331,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -969,16 +969,18 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0096-6762", "0028-4793"]
+                    addata: {
+                      issn: ["0096-6762", "0028-4793"]
+                    }
                   }
                 }
               }
@@ -988,7 +990,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -1052,17 +1054,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1136/bmj.h2575"]
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1136/bmj.h2575"]
+                    }
                   }
                 }
               }
@@ -1072,7 +1076,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -1160,17 +1164,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1136/bmj.h2575"]
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1136/bmj.h2575"]
+                    }
                   }
                 }
               }
@@ -1180,7 +1186,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -1261,17 +1267,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1136/bmj.h2575"]
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1136/bmj.h2575"]
+                    }
                   }
                 }
               }
@@ -1281,7 +1289,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -1366,22 +1374,24 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1136/bmj.h2575"]
+                    }
                   },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1136/bmj.h2575"]
+                  delivery: {
+                    deliveryCategory: ["Alma-P"]
                   }
-                },
-
-                delivery: {
-                  deliveryCategory: ["Alma-P"]
                 }
               }
             }
@@ -1390,7 +1400,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -1489,17 +1499,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1136/bmj.h2575"]
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1136/bmj.h2575"]
+                    }
                   }
                 }
               }
@@ -1509,7 +1521,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -1571,16 +1583,18 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["1543687X"]
+                    addata: {
+                      issn: ["1543687X"]
+                    }
                   }
                 }
               }
@@ -1590,7 +1604,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -1648,17 +1662,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1136/bmj.h2575"]
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1136/bmj.h2575"]
+                    }
                   }
                 }
               }
@@ -1668,7 +1684,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -2085,17 +2101,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1136/bmj.h2575"]
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1136/bmj.h2575"]
+                    }
                   }
                 }
               }
@@ -2105,7 +2123,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -2513,17 +2531,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1136/bmj.h2575"]
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1136/bmj.h2575"]
+                    }
                   }
                 }
               }
@@ -2533,7 +2553,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -2605,17 +2625,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1136/bmj.h2575"]
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1136/bmj.h2575"]
+                    }
                   }
                 }
               }
@@ -2625,7 +2647,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -2711,17 +2733,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["21582440"],
-                    doi: ["10.1177/2158244020915900"]
+                    addata: {
+                      issn: ["21582440"],
+                      doi: ["10.1177/2158244020915900"]
+                    }
                   }
                 }
               }
@@ -2731,7 +2755,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -2822,17 +2846,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1136/bmj.h2575"]
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1136/bmj.h2575"]
+                    }
                   }
                 }
               }
@@ -2842,7 +2868,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -2930,17 +2930,19 @@ describe("BrowZine Primo Adapter >", function() {
         inject(function ($compile, $rootScope) {
           $scope = $rootScope.$new();
 
-          $scope.$ctrl = {
-            parentCtrl: {
-              result: {
-                pnx: {
-                  display: {
-                    type: ["article"]
-                  },
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
 
-                  addata: {
-                    issn: ["0028-4793"],
-                    doi: ["10.1136/bmj.h2575"]
+                    addata: {
+                      issn: ["0028-4793"],
+                      doi: ["10.1136/bmj.h2575"]
+                    }
                   }
                 }
               }
@@ -2950,7 +2952,7 @@ describe("BrowZine Primo Adapter >", function() {
           searchResult = $compile(searchResult)($scope);
         });
 
-        $scope.$ctrl.parentCtrl.$element = searchResult;
+        $scope.$parent.$ctrl.$element = searchResult;
 
         jasmine.Ajax.install();
 
@@ -3026,17 +3028,19 @@ describe("BrowZine Primo Adapter >", function() {
       inject(function ($compile, $rootScope) {
         $scope = $rootScope.$new();
 
-        $scope.$ctrl = {
-          parentCtrl: {
-            result: {
-              pnx: {
-                display: {
-                  type: ["article"]
-                },
+        $scope = {
+          $parent: {
+            $ctrl: {
+              result: {
+                pnx: {
+                  display: {
+                    type: ["article"]
+                  },
 
-                addata: {
-                  issn: ["0028-4793"],
-                  doi: ["10.1136/bmj.h2575"]
+                  addata: {
+                    issn: ["0028-4793"],
+                    doi: ["10.1136/bmj.h2575"]
+                  }
                 }
               }
             }
@@ -3046,7 +3050,7 @@ describe("BrowZine Primo Adapter >", function() {
         searchResult = $compile(searchResult)($scope);
       });
 
-      $scope.$ctrl.parentCtrl.$element = searchResult;
+      $scope.$parent.$ctrl.$element = searchResult;
 
       jasmine.Ajax.install();
 
@@ -3490,16 +3494,18 @@ describe("BrowZine Primo Adapter >", function() {
       inject(function ($compile, $rootScope) {
         $scope = $rootScope.$new();
 
-        $scope.$ctrl = {
-          parentCtrl: {
+        $scope = {
+          $parent: {
+            $ctrl: {
 
+            }
           }
         };
 
         searchResult = $compile(searchResult)($scope);
       });
 
-      $scope.$ctrl.parentCtrl.$element = searchResult;
+      $scope.$parent.$ctrl.$element = searchResult;
 
       jasmine.Ajax.install();
 

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -180,16 +180,18 @@ describe("Primo Model >", function() {
 
   describe("primo model getScope method >", function() {
     it("should retrieve the scope from a search result", function() {
-      $scope.$ctrl = {
-        parentCtrl: {
-          result: {
-            pnx: {
-              display: {
-                type: ["journal"]
-              },
+      var $scope = {
+        $parent: {
+          $ctrl: {
+            result: {
+              pnx: {
+                display: {
+                  type: ["journal"]
+                },
 
-              addata: {
-                issn: ["0096-6762", "0028-4793"]
+                addata: {
+                  issn: ["0096-6762", "0028-4793"]
+                }
               }
             }
           }


### PR DESCRIPTION
## Summary - [BZ-7188](https://thirdiron.atlassian.net/browse/BZ-7188)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Updates Primo scope extraction to handle Primo object model for both Primo Angular v1.6 and Primo Angular v1.8

## Description

Seems the object model will be slightly refactored in the next platform major release. The Angular upgrade itself may be a red herring, with the actual breakage come from an object change in the next major release. Basically, in the current Primo we could access data from two object paths. In the next major Angular release, it looks like one of those paths, the path we initially used, will be removed.

TODO:
- Fix Primo Unit and Acceptance Tests (**DONE**)

## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->


- None
