### PR TITLE
feature/library-id-override-staging-handling-BZ-7275

### DIFF
--- a/src/360-core/browzine-360-core-adapter.js
+++ b/src/360-core/browzine-360-core-adapter.js
@@ -6,6 +6,8 @@ browzine.serSol360Core = (function() {
   function urlRewrite(url) {
     if (!url) {
       return;
+    } else if (url.indexOf("staging-api.thirdiron.com") > -1) {
+      return url;
     }
 
     return url.indexOf("public-api.thirdiron.com") > -1 ? url : url.replace("api.thirdiron.com", "public-api.thirdiron.com");

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -6,6 +6,8 @@ browzine.primo = (function() {
   function urlRewrite(url) {
     if (!url) {
       return;
+    } else if (url.indexOf("staging-api.thirdiron.com") > -1) {
+      return url;
     }
 
     return url.indexOf("public-api.thirdiron.com") > -1 ? url : url.replace("api.thirdiron.com", "public-api.thirdiron.com");

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -6,6 +6,8 @@ browzine.summon = (function() {
   function urlRewrite(url) {
     if (!url) {
       return;
+    } else if (url.indexOf("staging-api.thirdiron.com") > -1) {
+      return url;
     }
 
     return url.indexOf("public-api.thirdiron.com") > -1 ? url : url.replace("api.thirdiron.com", "public-api.thirdiron.com");

--- a/tests/unit/models/360-core.js
+++ b/tests/unit/models/360-core.js
@@ -173,11 +173,6 @@ describe("SerSol 360 Core Model >", function() {
       expect(serSol360Core.libraryIdOverride(serSol360Core.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
     });
 
-    it("should override the libraryId on the api endpoint even when an api endpoint is specified", function() {
-      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
-      expect(serSol360Core.libraryIdOverride(serSol360Core.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
-    });
-
     it("should return the customer supplied api endpoint when a libraryId is not specified", function() {
       delete browzine.libraryId;
       browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";

--- a/tests/unit/models/360-core.js
+++ b/tests/unit/models/360-core.js
@@ -158,6 +158,33 @@ describe("SerSol 360 Core Model >", function() {
     });
   });
 
+  describe("serSol360Core model libraryIdOverride method staging >", function() {
+    beforeEach(function() {
+      delete browzine.api;
+    });
+
+    afterEach(function() {
+      delete browzine.libraryId;
+      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
+    });
+
+    it("should not override the libraryId on the api endpoint when the libraryId is not specified", function() {
+      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
+      expect(serSol360Core.libraryIdOverride(serSol360Core.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
+    });
+
+    it("should override the libraryId on the api endpoint even when an api endpoint is specified", function() {
+      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
+      expect(serSol360Core.libraryIdOverride(serSol360Core.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
+    });
+
+    it("should return the customer supplied api endpoint when a libraryId is not specified", function() {
+      delete browzine.libraryId;
+      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
+      expect(serSol360Core.libraryIdOverride(serSol360Core.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
+    });
+  });
+
   describe("serSol360Core model getIssn method >", function() {
     it("should extract an issn from the identifiers array when available", function() {
       var title = titles[0];

--- a/tests/unit/models/360-core.js
+++ b/tests/unit/models/360-core.js
@@ -168,11 +168,6 @@ describe("SerSol 360 Core Model >", function() {
       browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
     });
 
-    it("should not override the libraryId on the api endpoint when the libraryId is not specified", function() {
-      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
-      expect(serSol360Core.libraryIdOverride(serSol360Core.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
-    });
-
     it("should return the customer supplied api endpoint when a libraryId is not specified", function() {
       delete browzine.libraryId;
       browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -295,6 +295,33 @@ describe("Primo Model >", function() {
     });
   });
 
+  describe("primo model libraryIdOverride method staging >", function() {
+    beforeEach(function() {
+      delete browzine.api;
+    });
+
+    afterEach(function() {
+      delete browzine.libraryId;
+      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
+    });
+
+    it("should not override the libraryId on the api endpoint when the libraryId is not specified", function() {
+      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
+      expect(primo.libraryIdOverride(primo.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
+    });
+
+    it("should override the libraryId on the api endpoint even when an api endpoint is specified", function() {
+      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
+      expect(primo.libraryIdOverride(primo.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
+    });
+
+    it("should return the customer supplied api endpoint when a libraryId is not specified", function() {
+      delete browzine.libraryId;
+      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
+      expect(primo.libraryIdOverride(primo.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
+    });
+  });
+
   describe("primo model shouldEnhance method >", function() {
     it("should not enhance a search result without scope data", function() {
       var scope = {};

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -310,11 +310,6 @@ describe("Primo Model >", function() {
       expect(primo.libraryIdOverride(primo.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
     });
 
-    it("should override the libraryId on the api endpoint even when an api endpoint is specified", function() {
-      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
-      expect(primo.libraryIdOverride(primo.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
-    });
-
     it("should return the customer supplied api endpoint when a libraryId is not specified", function() {
       delete browzine.libraryId;
       browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -305,11 +305,6 @@ describe("Primo Model >", function() {
       browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
     });
 
-    it("should not override the libraryId on the api endpoint when the libraryId is not specified", function() {
-      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
-      expect(primo.libraryIdOverride(primo.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
-    });
-
     it("should return the customer supplied api endpoint when a libraryId is not specified", function() {
       delete browzine.libraryId;
       browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -154,11 +154,6 @@ describe("Summon Model >", function() {
       expect(summon.libraryIdOverride(summon.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
     });
 
-    it("should override the libraryId on the api endpoint even when an api endpoint is specified", function() {
-      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
-      expect(summon.libraryIdOverride(summon.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
-    });
-
     it("should return the customer supplied api endpoint when a libraryId is not specified", function() {
       delete browzine.libraryId;
       browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -139,6 +139,33 @@ describe("Summon Model >", function() {
     });
   });
 
+  describe("summon model libraryIdOverride method staging >", function() {
+    beforeEach(function() {
+      delete browzine.api;
+    });
+
+    afterEach(function() {
+      delete browzine.libraryId;
+      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
+    });
+
+    it("should not override the libraryId on the api endpoint when the libraryId is not specified", function() {
+      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
+      expect(summon.libraryIdOverride(summon.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
+    });
+
+    it("should override the libraryId on the api endpoint even when an api endpoint is specified", function() {
+      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
+      expect(summon.libraryIdOverride(summon.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
+    });
+
+    it("should return the customer supplied api endpoint when a libraryId is not specified", function() {
+      delete browzine.libraryId;
+      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
+      expect(summon.libraryIdOverride(summon.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
+    });
+  });
+
   describe("summon model shouldEnhance method >", function() {
     it("should not enhance a search result without a document", function() {
       var scope = {};

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -149,11 +149,6 @@ describe("Summon Model >", function() {
       browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
     });
 
-    it("should not override the libraryId on the api endpoint when the libraryId is not specified", function() {
-      browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";
-      expect(summon.libraryIdOverride(summon.urlRewrite(browzine.api))).toEqual("https://staging-api.thirdiron.com/public/v1/libraries/XXX");
-    });
-
     it("should return the customer supplied api endpoint when a libraryId is not specified", function() {
       delete browzine.libraryId;
       browzine.api = "https://staging-api.thirdiron.com/public/v1/libraries/XXX";


### PR DESCRIPTION
## Summary - [BZ-7275](https://thirdiron.atlassian.net/browse/BZ-7275)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Handles staging api endpoint override when no libraryId is specified.

## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None
