### PR TITLE
Adding EOC notices to Primo

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ window.browzine = {
   articleRetractionWatchEnabled: true,
   articleRetractionWatchText: "Retracted Article",
 
+  articleExpressionOfConcernEnabled: true,
+  articleExpressionOfConcernText: "Expression of Concern",
+
   showFormatChoice: true,
   showLinkResolverLink: true,
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Care should be taken to validate JavaScript features used are available in IE11+
 
 * `npm run server` (Runs a local webserver, visit http://localhost:8080)
 * `npm run tunnel` (Creates an ngrok tunnel, place this in the "Summon 2.0 External Script", e.g. https://9f9981c8.ngrok.io/src/summon/browzine-summon-adapter.js)
+* For Primo, add the url given by the ngrok tunnel and add it to the custom.js file of the template package. Then upload that into the School of Mines Primo sandbox. Make sure to change the library ID and API key in order to fetch the data you want if you need to test something like retractions or EOCs.
 
 ### Running Tests
 

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -1120,7 +1120,7 @@ browzine.primo = (function() {
     showArticleLink: showArticleLink,
     showPrintRecords: showPrintRecords,
     showRetractionWatch: showRetractionWatch,
-    showExpressionOfConcern: showExpressionOfConcern;
+    showExpressionOfConcern: showExpressionOfConcern,
     showFormatChoice: showFormatChoice,
     showLinkResolverLink: showLinkResolverLink,
     enableLinkOptimizer: enableLinkOptimizer,

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -728,9 +728,7 @@ browzine.primo = (function() {
     return template;
   };
 
-  //There's a bit of a question on whether we would need a retraction notice/eoc notice on this as we'd only get to this function
-  //if we don't already have a PDF link-we might only link to these live unpaywall responses if they have a direct-to-PDF link
-  //But we may want to investigate this to be sure...
+  //TODO: BZ 8196 - Will address the need here for retraction/eoc handling as well as ironing out some logic.
   function unpaywallArticleLinkTemplate(articleLinkUrl) {
     var linkIcon = "https://assets.thirdiron.com/images/integrations/browzine-article-link-icon.svg";
     var articleLinkText = browzine.articleLinkViaUnpaywallText  || "Read Article (via Unpaywall)";
@@ -919,7 +917,7 @@ browzine.primo = (function() {
           libKeyLinkOptimizer.innerHTML += template;
         }
 
-        if (!directToPDFUrl && !articleLinkUrl && articleRetractionUrl && !articleEocNoticeUrl && isArticle(scope) && showRetractionWatch()) {
+        if (!directToPDFUrl && !articleLinkUrl && articleRetractionUrl && isArticle(scope) && showRetractionWatch()) {
           var template = retractionWatchLinkTemplate(articleRetractionUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -284,6 +284,7 @@ browzine.primo = (function() {
 
     if (isArticle(scope)) {
       if (data && data.expressionOfConcernNoticeUrl) {
+        console.log(data.expressionOfConcernNoticeUrl, 'here is our expressionOfConcernNoticeUrl');
         articleEocNoticeUrl = data.expressionOfConcernNoticeUrl;
       }
     }
@@ -542,7 +543,7 @@ browzine.primo = (function() {
     return articleEocNoticeUrl && showExpressionOfConcern();
   }
 
-  function directToPDFTemplate(directToPDFUrl, articleRetractionUrl) {
+  function directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl) {
     var pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-pdf-download-icon.svg";
     var pdfIconWidth = "12";
     var pdfIconMarginRight = "4.5px";
@@ -581,7 +582,7 @@ browzine.primo = (function() {
     return template;
   };
 
-  function articleLinkTemplate(articleLinkUrl, articleRetractionUrl) {
+  function articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl) {
     var linkIcon = "https://assets.thirdiron.com/images/integrations/browzine-article-link-icon.svg";
     var linkIconWidth = "12";
     var linkIconMarginRight = "4.5px";
@@ -919,7 +920,7 @@ browzine.primo = (function() {
         libKeyLinkOptimizer.style = "display: flex; justify-content: flex-start;";
 
         if (directToPDFUrl && isArticle(scope) && showDirectToPDFLink()) {
-          var template = directToPDFTemplate(directToPDFUrl, articleRetractionUrl);
+          var template = directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -248,7 +248,6 @@ browzine.primo = (function() {
     if (!isArticle(scope)) {
       return false;
     }
-    //We can maybe get rid of this now? Per Karl, the reasons for doing this may no longer matter. May need more investigation.
     if (!data || !data.hasOwnProperty("unpaywallUsable")) {
       return true;
     }
@@ -284,7 +283,6 @@ browzine.primo = (function() {
 
     if (isArticle(scope)) {
       if (data && data.expressionOfConcernNoticeUrl) {
-        console.log(data.expressionOfConcernNoticeUrl, 'here is our expressionOfConcernNoticeUrl');
         articleEocNoticeUrl = data.expressionOfConcernNoticeUrl;
       }
     }
@@ -555,9 +553,7 @@ browzine.primo = (function() {
       pdfIconWidth = "15";
       pdfIconMarginRight = "1.5px";
       articlePDFDownloadLinkText = browzine.articleRetractionWatchText || "Retracted Article";
-    }
-
-    if (showEocNoticeUI(articleEocNoticeUrl) && !showRetractionWatchUI(articleRetractionUrl)) {
+    } else if (showEocNoticeUI(articleEocNoticeUrl)) {
       directToPDFUrl = articleEocNoticeUrl;
       pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
       pdfIconWidth = "15";
@@ -594,9 +590,7 @@ browzine.primo = (function() {
       linkIconWidth = "15";
       linkIconMarginRight = "1.5px";
       articleLinkText = browzine.articleRetractionWatchText || "Retracted Article";
-    }
-
-    if (showEocNoticeUI(articleEocNoticeUrl) && !showRetractionWatchUI(articleRetractionUrl)) {
+    } else if (showEocNoticeUI(articleEocNoticeUrl)) {
       articleLinkUrl = articleEocNoticeUrl;
       linkIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
       linkIconWidth = "15";
@@ -709,9 +703,7 @@ browzine.primo = (function() {
       pdfIconWidth = "15";
       pdfIconMarginRight = "1.5px";
       articlePDFDownloadLinkText = browzine.articleRetractionWatchText || "Retracted Article";
-    }
-
-    if (showEocNoticeUI(articleEocNoticeUrl) && !showRetractionWatchUI(articleRetractionUrl)) {
+    } else if (showEocNoticeUI(articleEocNoticeUrl)) {
       directToPDFUrl = articleEocNoticeUrl;
       pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
       pdfIconWidth = "15";
@@ -770,9 +762,7 @@ browzine.primo = (function() {
       pdfIconWidth = "15";
       pdfIconMarginRight = "1.5px";
       articlePDFDownloadLinkText = browzine.articleRetractionWatchText || "Retracted Article";
-    }
-
-    if (showEocNoticeUI(articleEocNoticeUrl) && !showRetractionWatchUI(articleRetractionUrl)) {
+    } else if (showEocNoticeUI(articleEocNoticeUrl)) {
       directToPDFUrl = articleEocNoticeUrl;
       pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
       pdfIconWidth = "15";

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -486,7 +486,8 @@ describe("BrowZine Primo Adapter >", function() {
                   }
                 }
               },
-              "retractionNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1186/s11671-016-1523-5"
+              "retractionNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1186/s11671-016-1523-5",
+              "expressionOfConcernNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1186/s11671-016-1523-5",
             },
             "included": [
               {
@@ -518,6 +519,7 @@ describe("BrowZine Primo Adapter >", function() {
 
         expect(template.text().trim()).toContain("View Issue Contents");
         expect(template.text().trim()).toContain("Retracted Article");
+        expect(template.text().trim()).not.toContain("Expression of Concern");
 
         expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/8645/issues/8065238?showArticleInContext=doi:10.1186%2Fs11671-016-1523-5&utm_source=api_716");
         expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
@@ -754,7 +756,8 @@ describe("BrowZine Primo Adapter >", function() {
                   }
                 }
               },
-              "retractionNoticeUrl": "https://libkey.io/libraries/513/10.1162/jocn_a_00867"
+              "retractionNoticeUrl": "https://libkey.io/libraries/513/10.1162/jocn_a_00867",
+              "expressionOfConcernNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1162/jocn_a_00867",
             },
             "included": [
               {
@@ -784,13 +787,14 @@ describe("BrowZine Primo Adapter >", function() {
         jasmine.Ajax.uninstall();
       });
 
-      it("should show retraction notices when there is only an article link", function() {
+      it("should show retraction notices when there is only an article link", function () {
         var template = searchResult.find(".browzine");
 
         expect(template).toBeDefined();
 
         expect(template.text().trim()).toContain("View Issue Contents");
         expect(template.text().trim()).toContain("Retracted Article");
+        expect(template.text().trim()).not.toContain("Expression of Concern");
 
         expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://browzine.com/libraries/513/journals/32127/issues/7986254?showArticleInContext=doi:10.1162%2Fjocn_a_00867&utm_source=api_572");
         expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
@@ -1026,7 +1030,8 @@ describe("BrowZine Primo Adapter >", function() {
                   }
                 }
               },
-              "retractionNoticeUrl": "https://libkey.io/libraries/1466/10.1162/jocn_a_00867"
+              "retractionNoticeUrl": "https://libkey.io/libraries/1466/10.1162/jocn_a_00867",
+              "expressionOfConcernNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1162/jocn_a_00867",
             },
             "included": [
               {
@@ -1062,6 +1067,7 @@ describe("BrowZine Primo Adapter >", function() {
         expect(template).toBeDefined();
 
         expect(template.text().trim()).toContain("Retracted Article");
+        expect(template.text().trim()).not.toContain("Expression of Concern");
 
         expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://libkey.io/libraries/1466/10.1162/jocn_a_00867");
         expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
@@ -1278,7 +1284,8 @@ describe("BrowZine Primo Adapter >", function() {
                   }
                 }
               },
-              "retractionNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1186/s11671-016-1523-5"
+              "retractionNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1186/s11671-016-1523-5",
+              "expressionOfConcernNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1186/s11671-016-1523-5",
             },
             "included": [
               {
@@ -1311,6 +1318,7 @@ describe("BrowZine Primo Adapter >", function() {
 
         expect(template.text().trim()).toContain("View Issue Contents");
         expect(template.text().trim()).toContain("Retracted Article");
+        expect(template.text().trim()).not.toContain("Expression of Concern");
         expect(template.text().trim()).not.toContain("Read Article");
 
         expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/8645/issues/8065238?showArticleInContext=doi:10.1186%2Fs11671-016-1523-5&utm_source=api_716");

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -644,12 +644,10 @@ describe("BrowZine Primo Adapter >", function() {
         jasmine.Ajax.uninstall();
       });
 
-      //Need to edit the following tests to be about EOC rather than Retraction
       it("should have an enhanced browse article in browzine option", function() {
         var template = searchResult.find(".browzine");
 
         expect(template).toBeDefined();
-        console.log(template.text(), 'this is our template text');
 
         expect(template.text().trim()).toContain("View Issue Contents");
         expect(template.text().trim()).toContain("Expression of Concern");
@@ -1205,7 +1203,7 @@ describe("BrowZine Primo Adapter >", function() {
         });
       });
 
-      it("should open a new window when a retracted article link is clicked", function() {
+      it("should open a new window when an eoc article link is clicked", function() {
         spyOn(window, "open");
         searchResult.find(".browzine .browzine-article-link").click();
         expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307", "_blank");

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -554,6 +554,141 @@ describe("BrowZine Primo Adapter >", function() {
       });
     });
 
+    describe("search results article with both browzine web link and eoc article link >", function() {
+      beforeEach(function() {
+        primo = browzine.primo;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["1538-3598"],
+                      doi: ["10.1001/jama.298.4.413"]
+                    }
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$parent.$ctrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 4699582,
+              "type": "articles",
+              "title": "Efficacy of a Hip Protector to Prevent Hip Fracture in Nursing Home Residents",
+              "date": "2007-05-13",
+              "authors": "Kiel, Douglas P.; Magaziner, Jay; Zimmerman, Sheryl; Birge, Stanley J.",
+              "inPress": false,
+              "doi": "10.1001/jama.298.4.413",
+              "openAccess": true,
+              "fullTextFile": "https://develop.libkey.io/libraries/XXXX/articles/4699582/full-text-file?utm_source=api_716",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/4699582/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "413",
+              "endPage": "",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/10278/issues/4699582?showArticleInContext=doi:10.1001%2Fjama.298.4.413&utm_source=api_716",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 10278
+                  }
+                }
+              },
+              "expressionOfConcernNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1001/jama.298.4.413"
+            },
+            "included": [
+              {
+                "id": 10278,
+                "type": "journals",
+                "title": "JAMA: Journal of the American Medical Association",
+                "issn": "15383598",
+                "sjrValue": 6.695,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1538-3598.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/10278?utm_source=api_716"
+              }
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1001%2Fjama.298.4.413/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      //Need to edit the following tests to be about EOC rather than Retraction
+      it("should have an enhanced browse article in browzine option", function() {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+        console.log(template.text(), 'this is our template text');
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).toContain("Expression of Concern");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/10278/issues/4699582?showArticleInContext=doi:10.1001%2Fjama.298.4.413&utm_source=api_716");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.svg");
+
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1001/jama.298.4.413");
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function(done) {
+        requestAnimationFrame(function() {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function(coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/1538-3598.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when an eoc article link is clicked", function() {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-direct-to-pdf-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1001/jama.298.4.413", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function() {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/10278/issues/4699582?showArticleInContext=doi:10.1001%2Fjama.298.4.413&utm_source=api_716", "_blank");
+      });
+    });
+
     describe("retraction notice and only an article link >", function() {
       beforeEach(function() {
         primo = browzine.primo;
@@ -694,6 +829,139 @@ describe("BrowZine Primo Adapter >", function() {
       });
     });
 
+    describe("eoc notice and only an article link >", function() {
+      beforeEach(function() {
+        primo = browzine.primo;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["10837159"],
+                      doi: ["10.1634/theoncologist.8-4-307"]
+                    }
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$parent.$ctrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "expressionOfConcernNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307"
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show eoc notices when there is only an article link", function() {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).toContain("Expression of Concern");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.svg");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-article-link-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function(done) {
+        requestAnimationFrame(function() {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function(coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/1083-7159.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when an eoc article link is clicked", function() {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function() {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572", "_blank");
+      });
+    });
+
     describe("retraction notice and no pdf link or article link >", function() {
       beforeEach(function() {
         primo = browzine.primo;
@@ -819,6 +1087,128 @@ describe("BrowZine Primo Adapter >", function() {
         spyOn(window, "open");
         searchResult.find(".browzine .browzine-article-link").click();
         expect(window.open).toHaveBeenCalledWith("https://libkey.io/libraries/1466/10.1162/jocn_a_00867", "_blank");
+      });
+    });
+
+    describe("eoc notice and no pdf link or article link >", function() {
+      beforeEach(function() {
+        primo = browzine.primo;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["10837159"],
+                      doi: ["10.1634/theoncologist.8-4-307"]
+                    }
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$parent.$ctrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "",
+              "availableThroughBrowzine": false,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "expressionOfConcernNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307"
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show eoc notices when available even if no pdf link or article link available", function() {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("Expression of Concern");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-article-link-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function(done) {
+        requestAnimationFrame(function() {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function(coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/1083-7159.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when a retracted article link is clicked", function() {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307", "_blank");
       });
     });
 
@@ -957,6 +1347,144 @@ describe("BrowZine Primo Adapter >", function() {
         spyOn(window, "open");
         searchResult.find(".browzine .browzine-web-link").click();
         expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/8645/issues/8065238?showArticleInContext=doi:10.1186%2Fs11671-016-1523-5&utm_source=api_716", "_blank");
+      });
+    });
+
+    describe("search results article with both eoc article link and article link >", function() {
+      beforeEach(function() {
+        primo = browzine.primo;
+        browzine.showFormatChoice = true;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["0020-7136"],
+                      doi: ["10.1002/ijc.25451"]
+                    }
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$parent.$ctrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 26652324,
+              "type": "articles",
+              "title": "A tritherapy combination of a fusion protein vaccine with immune‐modulating doses of sequential chemotherapies in an optimized regimen completely eradicates large tumors in mice",
+              "date": "2010-05-12",
+              "authors": "Song, Xinxin; Guo, Wenzhong; Cui, Jianfeng; Qian, Xinlai; Yi, Linan; Chang, Mengjiao; Cai, Qiliang; Zhao, Qingzheng",
+              "inPress": false,
+              "doi": "10.1002/ijc.25451",
+              "ILLURL": "",
+              "pmid": "",
+              "openAccess": true,
+              "fullTextFile": "https://develop.libkey.io/libraries/XXXX/articles/26652324/full-text-file?utm_source=api_716",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/26652324/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "326",
+              "endPage": "",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/13016/issues/4629899?showArticleInContext=doi:10.1002%2Fijc.25451&utm_source=api_716",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 13016
+                  }
+                }
+              },
+              "expressionOfConcernNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451"
+            },
+            "included": [
+              {
+                "id": 13016,
+                "type": "journals",
+                "title": "International Journal of Cancer",
+                "issn": "00207136",
+                "sjrValue": 2.259,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/0020-7136.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/13016?utm_source=api_716"
+              }
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1002%2Fijc.25451/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+        delete browzine.showFormatChoice;
+      });
+
+      it("should have an enhanced browse article showing eoc only", function() {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).toContain("Expression of Concern");
+        expect(template.text().trim()).not.toContain("Read Article");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/13016/issues/4629899?showArticleInContext=doi:10.1002%2Fijc.25451&utm_source=api_716");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.svg");
+
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451");
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function(done) {
+        requestAnimationFrame(function() {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function(coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/0020-7136.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when an eoc article link is clicked", function() {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-direct-to-pdf-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function() {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/13016/issues/4629899?showArticleInContext=doi:10.1002%2Fijc.25451&utm_source=api_716", "_blank");
       });
     });
 

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -1,5 +1,5 @@
 describe("Primo Model >", function() {
-  var primo = {}, journalResponse = {}, articleResponse = {};
+  var primo = {}, journalResponse = {}, articleResponse = {}, eocArticleResponse = {};
 
   beforeEach(function() {
     primo = browzine.primo;
@@ -23,7 +23,18 @@ describe("Primo Model >", function() {
         "coverImageUrl": "https://assets.thirdiron.com/default-journal-cover.png",
         "browzineEnabled": false,
         "externalLink": "http://za2uf4ps7f.search.serialssolutions.com/?V=1.0&N=100&L=za2uf4ps7f&S=I_M&C=0096-6762"
-      }]
+        },
+        {
+          "id": 13016,
+          "type": "journals",
+          "title": "International Journal of Cancer",
+          "issn": "00207136",
+          "sjrValue": 2.259,
+          "coverImageUrl": "https://assets.thirdiron.com/images/covers/0020-7136.png",
+          "browzineEnabled": true,
+          "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/13016?utm_source=api_716"
+        }
+      ]
     };
 
     articleResponse = {
@@ -53,6 +64,38 @@ describe("Primo Model >", function() {
         "browzineWebLink": "https://develop.browzine.com/libraries/XXX/journals/18126"
       }]
     };
+
+    eocArticleResponse = {
+      "data": {
+        "id": 26652324,
+        "type": "articles",
+        "title": "A tritherapy combination of a fusion protein vaccine with immune‐modulating doses of sequential chemotherapies in an optimized regimen completely eradicates large tumors in mice",
+        "date": "2010-05-12",
+        "authors": "Song, Xinxin; Guo, Wenzhong; Cui, Jianfeng; Qian, Xinlai; Yi, Linan; Chang, Mengjiao; Cai, Qiliang; Zhao, Qingzheng",
+        "inPress": false,
+        "doi": "10.1002/ijc.25451",
+        "openAccess": true,
+        "startPage": "326",
+        "endPage": "",
+        "availableThroughBrowzine": true,
+        "fullTextFile": "https://develop.libkey.io/libraries/XXXX/articles/26652324/full-text-file?utm_source=api_716",
+        "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/26652324/content-location",
+        "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/13016/issues/4629899?showArticleInContext=doi:10.1002%2Fijc.25451&utm_source=api_716",
+        "expressionOfConcernNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451",
+        "included": [
+          {
+            "id": 13016,
+            "type": "journals",
+            "title": "International Journal of Cancer",
+            "issn": "00207136",
+            "sjrValue": 2.259,
+            "coverImageUrl": "https://assets.thirdiron.com/images/covers/0020-7136.png",
+            "browzineEnabled": true,
+            "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/13016?utm_source=api_716"
+          }
+        ]
+      }
+    }
   });
 
   afterEach(function() {
@@ -947,7 +990,7 @@ describe("Primo Model >", function() {
     it("should include a browzineWebLink in the BrowZine API response for a journal", function() {
       var data = primo.getData(journalResponse);
       expect(data).toBeDefined();
-      expect(primo.getBrowZineWebLink(data)).toEqual("https://browzine.com/libraries/XXX/journals/10292");
+      expect(primo.getBrowZineWebLink(data)).toEqual("https://develop.browzine.com/libraries/XXXX/journals/13016?utm_source=api_716");
     });
 
     it("should include a browzineWebLink in the BrowZine API response for an article", function() {
@@ -967,7 +1010,7 @@ describe("Primo Model >", function() {
             },
 
             addata: {
-              issn: ["0096-6762", "0028-4793"]
+              issn: ["0096-6762", "0028-4793", "0020-7136"]
             }
           }
         }
@@ -979,7 +1022,7 @@ describe("Primo Model >", function() {
       expect(data).toBeDefined();
       expect(journal).toBeNull();
 
-      expect(primo.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
+      expect(primo.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0020-7136.png");
     });
 
     it("should include a coverImageUrl in the BrowZine API response for an article", function() {
@@ -1016,7 +1059,7 @@ describe("Primo Model >", function() {
             },
 
             addata: {
-              issn: ["0096-6762", "0028-4793"]
+              issn: ["0096-6762", "0028-4793", "0020-7136"]
             }
           }
         }
@@ -1028,7 +1071,7 @@ describe("Primo Model >", function() {
       expect(data).toBeDefined();
       expect(journal).toBeNull();
 
-      expect(primo.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
+      expect(primo.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0020-7136.png");
     });
   });
 
@@ -1075,6 +1118,7 @@ describe("Primo Model >", function() {
 
     it("should not return data when the journal is not browzineEnabled", function() {
       journalResponse.data[0].browzineEnabled = false;
+      journalResponse.data[2].browzineEnabled = false;
       var data = primo.getData(journalResponse);
       expect(data).toEqual(undefined);
     });
@@ -1147,6 +1191,7 @@ describe("Primo Model >", function() {
       };
 
       journalResponse.data[0].browzineEnabled = false;
+      journalResponse.data[2].browzineEnabled = false;
       var data = primo.getData(journalResponse);
 
       expect(data).toEqual(undefined);
@@ -1217,6 +1262,7 @@ describe("Primo Model >", function() {
       };
 
       journalResponse.data[0].browzineEnabled = false;
+      journalResponse.data[2].browzineEnabled = false;
       var data = primo.getData(journalResponse);
 
       expect(data).toEqual(undefined);
@@ -1287,6 +1333,7 @@ describe("Primo Model >", function() {
       };
 
       journalResponse.data[0].browzineEnabled = false;
+      journalResponse.data[2].browzineEnabled = false;
       var data = primo.getData(journalResponse);
 
       expect(data).toEqual(undefined);
@@ -1294,6 +1341,77 @@ describe("Primo Model >", function() {
       expect(primo.getArticleRetractionUrl(scope, data)).toEqual(null);
     });
   });
+
+  describe("primo model getArticleEOCNoticeUrl method >", function () {
+    it("should not return an eoc url for journal search results", function() {
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["journal"]
+            },
+
+            addata: {
+              issn: ["0096-6762", "0028-4793, 0020-7136"]
+            }
+          }
+        }
+      };
+
+      var data = primo.getData(journalResponse);
+
+      expect(data).toBeDefined();
+
+      expect(primo.getArticleEOCNoticeUrl(scope, data)).toBeNull();
+    });
+
+    it("should return an eoc url for article search results", function() {
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["article"]
+            },
+
+            addata: {
+              issn: ["0020-7136"],
+              doi: ["10.1002/ijc.25451"]
+            }
+          }
+        }
+      };
+
+      var data = primo.getData(eocArticleResponse);
+
+      expect(data).toBeDefined();
+
+      expect(primo.getArticleEOCNoticeUrl(scope, data)).toEqual("https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451");
+    });
+
+    it("should not return an eoc url for article search results with no doi and in a journal that is not browzineEnabled", function() {
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["article"]
+            },
+
+            addata: {
+              issn: ["0020-7136"]
+            }
+          }
+        }
+      };
+
+      journalResponse.data[0].browzineEnabled = false;
+      journalResponse.data[2].browzineEnabled = false;
+      var data = primo.getData(journalResponse);
+
+      expect(data).toEqual(undefined);
+
+      expect(primo.getArticleEOCNoticeUrl(scope, data)).toEqual(null);
+    });
+  })
 
   describe("primo model isTrustedRepository method >", function() {
     it("should expect non nih.gov and non europepmc.org repositories to be untrusted", function() {
@@ -1870,6 +1988,36 @@ describe("Primo Model >", function() {
     });
   });
 
+  describe("primo model showExpressionOfConcern method >", function() {
+    beforeEach(function() {
+      delete browzine.articleExpressionOfConcernEnabled;
+    });
+
+    afterEach(function() {
+      delete browzine.articleExpressionOfConcernEnabled;
+    });
+
+    it("should enable expression of concern when configuration property is undefined", function() {
+      delete browzine.articleExpressionOfConcernEnabled;
+      expect(primo.showExpressionOfConcern()).toEqual(true);
+    });
+
+    it("should enable expression of concern when configuration property is null", function() {
+      browzine.articleExpressionOfConcernEnabled = null;
+      expect(primo.showExpressionOfConcern()).toEqual(true);
+    });
+
+    it("should enable expression of concern when configuration property is true", function() {
+      browzine.articleExpressionOfConcernEnabled = true;
+      expect(primo.showExpressionOfConcern()).toEqual(true);
+    });
+
+    it("should disable expression of concern when configuration property is false", function() {
+      browzine.articleExpressionOfConcernEnabled = false;
+      expect(primo.showExpressionOfConcern()).toEqual(false);
+    });
+  });
+
   describe("primo model showFormatChoice method >", function() {
     beforeEach(function() {
       delete browzine.showFormatChoice;
@@ -2086,6 +2234,7 @@ describe("Primo Model >", function() {
       delete browzine.primoArticlePDFDownloadLinkText;
 
       delete browzine.articleRetractionWatchText;
+      delete browzine.articleExpressionOfConcernText;
     });
 
     afterEach(function() {
@@ -2093,6 +2242,7 @@ describe("Primo Model >", function() {
       delete browzine.primoArticlePDFDownloadLinkText;
 
       delete browzine.articleRetractionWatchText;
+      delete browzine.articleExpressionOfConcernText;
     });
 
     it("should build a direct to pdf template for article search results", function() {
@@ -2236,6 +2386,67 @@ describe("Primo Model >", function() {
 
       expect(template).toContain("Retracted Article PDF");
     });
+
+    it("should build a direct to pdf template for article search results when eoc available and expression of concern enabled", function() {
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["article"]
+            },
+
+            addata: {
+              issn: ["0020-7136"],
+              doi: ["10.1002/ijc.25451"]
+            }
+          }
+        }
+      };
+
+      var data = primo.getData(eocArticleResponse);
+      var directToPDFUrl = primo.getDirectToPDFUrl(scope, data);
+      var articleRetractionUrl = primo.getArticleRetractionUrl(scope, data);
+      var articleEOCUrl = primo.getArticleEOCNoticeUrl(scope, data);
+      var template = primo.directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEOCUrl);
+
+      expect(data).toBeDefined();
+      expect(directToPDFUrl).toBeDefined();
+
+      expect(template).toBeDefined();
+
+      expect(template).toEqual("<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'><a class='browzine-direct-to-pdf-link' href='https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451' target='_blank' onclick='browzine.primo.transition(event, this)'><img alt='BrowZine PDF Icon' src='https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg' class='browzine-pdf-icon' style='margin-bottom: -3px; margin-right: 1.5px;' aria-hidden='true' width='15' height='16'/> <span class='browzine-web-link-text'>Expression of Concern</span> <md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon></a></div>");
+
+      expect(template).toContain("Expression of Concern");
+      expect(template).toContain("https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451");
+      expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+    });
+
+    it("should apply the articleExpressionOfConcernText config property when eoc notice available and eoc enabled", function() {
+      browzine.articleExpressionOfConcernText = "Expression of Concern PDF";
+
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["article"]
+            },
+
+            addata: {
+              issn: ["0020-7136"],
+              doi: ["10.1002/ijc.25451"]
+            }
+          }
+        }
+      };
+
+      var data = primo.getData(eocArticleResponse);
+      var directToPDFUrl = primo.getDirectToPDFUrl(scope, data);
+      var articleRetractionUrl = primo.getArticleRetractionUrl(scope, data);
+      var articleEOCUrl = primo.getArticleEOCNoticeUrl(scope, data);
+      var template = primo.directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEOCUrl);
+
+      expect(template).toContain("Expression of Concern PDF");
+    });
   });
 
   describe("primo model articleLinkTemplate method >", function() {
@@ -2376,6 +2587,75 @@ describe("Primo Model >", function() {
     });
   });
 
+  describe("primo model eocLinkTemplate method >", function() {
+    beforeEach(function() {
+      delete browzine.articleExpressionOfConcernEnabled;
+      delete browzine.articleExpressionOfConcernText;
+    });
+
+    afterEach(function() {
+      delete browzine.articleExpressionOfConcernEnabled;
+      delete browzine.articleExpressionOfConcernText;
+    });
+
+    it("should build an expression of concern template for article search results", function() {
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["article"]
+            },
+
+            addata: {
+              issn: ["0020-7136"],
+              doi: ["10.1002/ijc.25451"]
+            }
+          }
+        }
+      };
+
+      var data = primo.getData(eocArticleResponse);
+      var articleEocNoticeUrl = primo.getArticleEOCNoticeUrl(scope, data)
+      var template = primo.eocLinkTemplate(articleEocNoticeUrl);
+
+      expect(data).toBeDefined();
+      expect(articleEocNoticeUrl).toBeDefined();
+
+      expect(template).toBeDefined();
+
+      expect(template).toEqual("<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'><a class='browzine-article-link' href='https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451' target='_blank' onclick='browzine.primo.transition(event, this)'><img alt='BrowZine Article Link Icon' src='https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg' class='browzine-article-link-icon' style='margin-bottom: -3px; margin-right: 1.5px;' aria-hidden='true' width='15' height='16'/> <span class='browzine-article-link-text'>Expression of Concern</span> <md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon></a></div>");
+
+      expect(template).toContain("Expression of Concern");
+      expect(template).toContain("https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451");
+      expect(template).toContain("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+    });
+
+    it("should apply the articleExpressionOfConcernText config property", function() {
+      browzine.articleExpressionOfConcernText = "Expression of Concern (Proceed with Caution)";
+
+      var scope = {
+        result: {
+          pnx: {
+            display: {
+              type: ["article"]
+            },
+
+            addata: {
+              issn: ["0020-7136"],
+              doi: ["10.1002/ijc.25451"]
+            }
+          }
+        }
+      };
+
+      var data = primo.getData(eocArticleResponse);
+      var articleEocNoticeUrl = primo.getArticleEOCNoticeUrl(scope, data)
+      var template = primo.eocLinkTemplate(articleEocNoticeUrl);
+
+      expect(template).toContain("Expression of Concern (Proceed with Caution)");
+    });
+  });
+
   describe("primo model browzineWebLinkTemplate method >", function() {
     it("should build an enhancement template for journal search results", function() {
       var scope = {
@@ -2386,12 +2666,13 @@ describe("Primo Model >", function() {
             },
 
             addata: {
-              issn: ["0096-6762", "0028-4793"]
+              issn: ["0096-6762", "0028-4793", "0020-7136"]
             }
           }
         }
       };
 
+      journalResponse.data[2].browzineEnabled = false;
       var data = primo.getData(journalResponse);
       var browzineWebLink = primo.getBrowZineWebLink(data);
       var template = primo.browzineWebLinkTemplate(scope, browzineWebLink);

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -24,16 +24,6 @@ describe("Primo Model >", function() {
         "browzineEnabled": false,
         "externalLink": "http://za2uf4ps7f.search.serialssolutions.com/?V=1.0&N=100&L=za2uf4ps7f&S=I_M&C=0096-6762"
         },
-        {
-          "id": 13016,
-          "type": "journals",
-          "title": "International Journal of Cancer",
-          "issn": "00207136",
-          "sjrValue": 2.259,
-          "coverImageUrl": "https://assets.thirdiron.com/images/covers/0020-7136.png",
-          "browzineEnabled": true,
-          "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/13016?utm_source=api_716"
-        }
       ]
     };
 
@@ -990,7 +980,7 @@ describe("Primo Model >", function() {
     it("should include a browzineWebLink in the BrowZine API response for a journal", function() {
       var data = primo.getData(journalResponse);
       expect(data).toBeDefined();
-      expect(primo.getBrowZineWebLink(data)).toEqual("https://develop.browzine.com/libraries/XXXX/journals/13016?utm_source=api_716");
+      expect(primo.getBrowZineWebLink(data)).toEqual("https://browzine.com/libraries/XXX/journals/10292");
     });
 
     it("should include a browzineWebLink in the BrowZine API response for an article", function() {
@@ -1010,7 +1000,7 @@ describe("Primo Model >", function() {
             },
 
             addata: {
-              issn: ["0096-6762", "0028-4793", "0020-7136"]
+              issn: ["0096-6762", "0028-4793"]
             }
           }
         }
@@ -1022,7 +1012,7 @@ describe("Primo Model >", function() {
       expect(data).toBeDefined();
       expect(journal).toBeNull();
 
-      expect(primo.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0020-7136.png");
+      expect(primo.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
     });
 
     it("should include a coverImageUrl in the BrowZine API response for an article", function() {
@@ -1059,7 +1049,7 @@ describe("Primo Model >", function() {
             },
 
             addata: {
-              issn: ["0096-6762", "0028-4793", "0020-7136"]
+              issn: ["0096-6762", "0028-4793"]
             }
           }
         }
@@ -1071,7 +1061,7 @@ describe("Primo Model >", function() {
       expect(data).toBeDefined();
       expect(journal).toBeNull();
 
-      expect(primo.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0020-7136.png");
+      expect(primo.getCoverImageUrl(scope, data, journal)).toEqual("https://assets.thirdiron.com/images/covers/0028-4793.png");
     });
   });
 
@@ -1118,7 +1108,6 @@ describe("Primo Model >", function() {
 
     it("should not return data when the journal is not browzineEnabled", function() {
       journalResponse.data[0].browzineEnabled = false;
-      journalResponse.data[2].browzineEnabled = false;
       var data = primo.getData(journalResponse);
       expect(data).toEqual(undefined);
     });
@@ -1191,7 +1180,6 @@ describe("Primo Model >", function() {
       };
 
       journalResponse.data[0].browzineEnabled = false;
-      journalResponse.data[2].browzineEnabled = false;
       var data = primo.getData(journalResponse);
 
       expect(data).toEqual(undefined);
@@ -1262,7 +1250,6 @@ describe("Primo Model >", function() {
       };
 
       journalResponse.data[0].browzineEnabled = false;
-      journalResponse.data[2].browzineEnabled = false;
       var data = primo.getData(journalResponse);
 
       expect(data).toEqual(undefined);
@@ -1333,7 +1320,6 @@ describe("Primo Model >", function() {
       };
 
       journalResponse.data[0].browzineEnabled = false;
-      journalResponse.data[2].browzineEnabled = false;
       var data = primo.getData(journalResponse);
 
       expect(data).toEqual(undefined);
@@ -1404,7 +1390,6 @@ describe("Primo Model >", function() {
       };
 
       journalResponse.data[0].browzineEnabled = false;
-      journalResponse.data[2].browzineEnabled = false;
       var data = primo.getData(journalResponse);
 
       expect(data).toEqual(undefined);
@@ -2422,7 +2407,7 @@ describe("Primo Model >", function() {
     });
 
     it("should apply the articleExpressionOfConcernText config property when eoc notice available and eoc enabled", function() {
-      browzine.articleExpressionOfConcernText = "Expression of Concern PDF";
+      browzine.articleExpressionOfConcernText = "An area of grave concern";
 
       var scope = {
         result: {
@@ -2445,7 +2430,7 @@ describe("Primo Model >", function() {
       var articleEOCUrl = primo.getArticleEOCNoticeUrl(scope, data);
       var template = primo.directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEOCUrl);
 
-      expect(template).toContain("Expression of Concern PDF");
+      expect(template).toContain("An area of grave concern");
     });
   });
 
@@ -2672,7 +2657,7 @@ describe("Primo Model >", function() {
         }
       };
 
-      journalResponse.data[2].browzineEnabled = false;
+      journalResponse.data[1].browzineEnabled = false;
       var data = primo.getData(journalResponse);
       var browzineWebLink = primo.getBrowZineWebLink(data);
       var template = primo.browzineWebLinkTemplate(scope, browzineWebLink);


### PR DESCRIPTION
## Summary - [BZ-7639](https://thirdiron.atlassian.net/browse/BZ-7639)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

This release will add Expression of Concern notices to Primo instances, similar to the pre-existing Retraction notices.

## Description

Before EOC Notifications:
![CleanShot 2023-09-26 at 12 26 10](https://github.com/thirdiron/browzine-discovery-service-adapters/assets/87537108/bea1ef67-a1af-45bc-a542-f30c9966f7fc)


After EOC Notifications:
![CleanShot 2023-09-26 at 12 05 03](https://github.com/thirdiron/browzine-discovery-service-adapters/assets/87537108/8fd2b75d-c2fd-4a50-9189-87578d7bc9c4)


## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None


[BZ-7639]: https://thirdiron.atlassian.net/browse/BZ-7639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ