### PR TITLE
Remove the unused discoveryServiceBehavior value

### DIFF
--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -637,7 +637,6 @@ describe("BrowZine Primo Adapter >", function() {
               {
                 "id": 513,
                 "type": "libraries",
-                "discoveryServiceBehavior": "classic"
               }
             ]
           })
@@ -776,7 +775,6 @@ describe("BrowZine Primo Adapter >", function() {
               {
                 "id": 1466,
                 "type": "libraries",
-                "discoveryServiceBehavior": "classic"
               }
             ]
           })

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -417,7 +417,6 @@ describe("BrowZine Summon Adapter >", function() {
               {
                 "id": 513,
                 "type": "libraries",
-                "discoveryServiceBehavior": "classic"
               }
             ]
           })
@@ -532,7 +531,6 @@ describe("BrowZine Summon Adapter >", function() {
               {
                 "id": 1466,
                 "type": "libraries",
-                "discoveryServiceBehavior": "classic"
               }
             ]
           })


### PR DESCRIPTION
## Summary

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Remove a value from the tests that has already been removed from the API in the CMS repo

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

We removed it from the public API as part of BZ-7503, and it was only ever potentially used by this repo, so let's get rid of it from the fixture data in this repo. 

We ended up not actually using this, since our strategy changed from the "onelink" approach that this setting was intended to express.


## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None
