### PR TITLE
Discovery Service Adapters do not call unpaywall when unpaywallUsable is false

### DIFF
--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -872,7 +872,7 @@ browzine.primo = (function() {
   };
 
   function shouldUnpaywallLiveCallWhen404(response) {
-    if (response.hasOwnProperty('meta')&& response.meta.hasOwnProperty('unpaywallUsable')) {
+    if (response.hasOwnProperty('meta') && response.meta.hasOwnProperty('unpaywallUsable')) {
       return response.meta.unpaywallUsable;
     } else {
       return true;

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -871,11 +871,11 @@ browzine.primo = (function() {
     return validation;
   };
 
-  function shouldUnpaywallLiveCallWhen404(response) {
-    if (response.hasOwnProperty('meta') && response.meta.hasOwnProperty('unpaywallUsable')) {
-      return response.meta.unpaywallUsable;
+  function shouldAvoidUnpaywall(response) {
+    if (response.hasOwnProperty('meta') && response.meta.hasOwnProperty('avoidUnpaywall')) {
+      return response.meta.avoidUnpaywall;
     } else {
-      return true;
+      return false;
     };
   }
 
@@ -995,8 +995,8 @@ browzine.primo = (function() {
       if ((request.readyState == XMLHttpRequest.DONE && request.status == 404) || (isArticle(scope) && (!directToPDFUrl && !articleLinkUrl && unpaywallUsable))) {
 
         var response = JSON.parse(request.response || '{}');
-        var shouldUnpaywallLiveCall = shouldUnpaywallLiveCallWhen404(response);
-        if (!shouldUnpaywallLiveCall) {
+        var shouldAvoidUnpaywallLiveCall = shouldAvoidUnpaywall(response);
+        if (shouldAvoidUnpaywallLiveCall) {
           return
         }
 

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -872,8 +872,8 @@ browzine.primo = (function() {
   };
 
   function shouldUnpaywallLiveCallWhen404(response) {
-    if (response.hasOwnProperty('unpaywallUsable')) {
-      return response.unpaywallUsable;
+    if (response.hasOwnProperty('meta')&& response.meta.hasOwnProperty('unpaywallUsable')) {
+      return response.meta.unpaywallUsable;
     } else {
       return true;
     };

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -121,7 +121,7 @@ browzine.primo = (function() {
 
     if (isArticle(scope) && getDoi(scope)) {
       var doi = getDoi(scope);
-      endpoint = api + "/articles/doi/" + doi + "?include=journal,library";
+      endpoint = api + "/articles/doi/" + doi + "?include=journal,library&include_suppressed=true";
     }
 
     if (isArticle(scope) && !getDoi(scope) && getIssn(scope)) {
@@ -871,6 +871,14 @@ browzine.primo = (function() {
     return validation;
   };
 
+  function shouldUnpaywallLiveCallWhen404(response) {
+    if (response.hasOwnProperty('unpaywallUsable')) {
+      return response.unpaywallUsable;
+    } else {
+      return true;
+    };
+  }
+
   function searchResult($scope) {
     var scope = getScope($scope);
 
@@ -985,6 +993,13 @@ browzine.primo = (function() {
       }
 
       if ((request.readyState == XMLHttpRequest.DONE && request.status == 404) || (isArticle(scope) && (!directToPDFUrl && !articleLinkUrl && unpaywallUsable))) {
+
+        var response = JSON.parse(request.response || '{}');
+        var shouldUnpaywallLiveCall = shouldUnpaywallLiveCallWhen404(response);
+        if (!shouldUnpaywallLiveCall) {
+          return
+        }
+
         var endpoint = getUnpaywallEndpoint(scope);
         if (endpoint && isUnpaywallEnabled()) {
           var requestUnpaywall = new XMLHttpRequest();

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -121,7 +121,7 @@ browzine.primo = (function() {
 
     if (isArticle(scope) && getDoi(scope)) {
       var doi = getDoi(scope);
-      endpoint = api + "/articles/doi/" + doi + "?include=journal,library&include_suppressed=true";
+      endpoint = api + "/articles/doi/" + doi + "?include=journal,library";
     }
 
     if (isArticle(scope) && !getDoi(scope) && getIssn(scope)) {

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -887,7 +887,7 @@ browzine.summon = (function() {
   };
 
   function shouldUnpaywallLiveCallWhen404(response) {
-    if (response.hasOwnProperty('unpaywallUsable')) {
+    if (response.hasOwnProperty('meta') && response.meta.hasOwnProperty('unpaywallUsable')) {
       return response.unpaywallUsable;
     } else {
       return true;

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -886,11 +886,11 @@ browzine.summon = (function() {
     return primaryColor;
   };
 
-  function shouldUnpaywallLiveCallWhen404(response) {
-    if (response.hasOwnProperty('meta') && response.meta.hasOwnProperty('unpaywallUsable')) {
-      return response.meta.unpaywallUsable;
+  function shouldAvoidUnpaywall(response) {
+    if (response.hasOwnProperty('meta') && response.meta.hasOwnProperty('avoidUnpaywall')) {
+      return response.meta.avoidUnpaywall;
     } else {
-      return true;
+      return false;
     };
   }
 
@@ -1001,8 +1001,8 @@ browzine.summon = (function() {
       if ((request.readyState == XMLHttpRequest.DONE && request.status == 404) || (isArticle(scope) && (!directToPDFUrl && !articleLinkUrl && unpaywallUsable))) {
 
         var response = JSON.parse(request.response || '{}');
-        var shouldUnpaywallLiveCall = shouldUnpaywallLiveCallWhen404(response);
-        if (!shouldUnpaywallLiveCall) {
+        var shouldAvoidUnpaywallLiveCall = shouldAvoidUnpaywall(response);
+        if (shouldAvoidUnpaywallLiveCall) {
           return
         }
 

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -886,6 +886,14 @@ browzine.summon = (function() {
     return primaryColor;
   };
 
+  function shouldUnpaywallLiveCallWhen404(response) {
+    if (response.hasOwnProperty('unpaywallUsable')) {
+      return response.unpaywallUsable;
+    } else {
+      return true;
+    };
+  }
+
   function adapter(documentSummary) {
     var scope = getScope(documentSummary);
 
@@ -991,6 +999,13 @@ browzine.summon = (function() {
       }
 
       if ((request.readyState == XMLHttpRequest.DONE && request.status == 404) || (isArticle(scope) && (!directToPDFUrl && !articleLinkUrl && unpaywallUsable))) {
+
+        var response = JSON.parse(request.response || '{}');
+        var shouldUnpaywallLiveCall = shouldUnpaywallLiveCallWhen404(response);
+        if (!shouldUnpaywallLiveCall) {
+          return
+        }
+
         var endpoint = getUnpaywallEndpoint(scope);
 
         if (endpoint && isUnpaywallEnabled()) {

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -109,7 +109,7 @@ browzine.summon = (function() {
 
     if (isArticle(scope) && getDoi(scope)) {
       var doi = getDoi(scope);
-      endpoint = api + "/articles/doi/" + doi + "?include=journal,library";
+      endpoint = api + "/articles/doi/" + doi + "?include=journal,library&include_suppressed=true";
     }
 
     if (isArticle(scope) && !getDoi(scope) && getIssn(scope)) {

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -109,7 +109,7 @@ browzine.summon = (function() {
 
     if (isArticle(scope) && getDoi(scope)) {
       var doi = getDoi(scope);
-      endpoint = api + "/articles/doi/" + doi + "?include=journal,library&include_suppressed=true";
+      endpoint = api + "/articles/doi/" + doi + "?include=journal,library";
     }
 
     if (isArticle(scope) && !getDoi(scope) && getIssn(scope)) {

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -888,7 +888,7 @@ browzine.summon = (function() {
 
   function shouldUnpaywallLiveCallWhen404(response) {
     if (response.hasOwnProperty('meta') && response.meta.hasOwnProperty('unpaywallUsable')) {
-      return response.unpaywallUsable;
+      return response.meta.unpaywallUsable;
     } else {
       return true;
     };

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -4070,7 +4070,7 @@ describe("BrowZine Primo Adapter >", function() {
             "status": '404'
           }],
           "meta": {
-            "unpaywallUsable": false
+            "avoidUnpaywall": true
           }
         })
       });
@@ -4086,11 +4086,11 @@ describe("BrowZine Primo Adapter >", function() {
       jasmine.Ajax.uninstall();
     });
 
-    it('does not call unpaywall when unpaywallUsable=false', function () {
+    it('does not call unpaywall when avoidUnpaywall=true', function () {
       //We are expecting to call our TIApi but not Unpaywall, thus we should only see one request in the jasmine ajax request queue
       const thirdIronApiDoiRequestResponse = jasmine.Ajax.requests.mostRecent().response
       expect(jasmine.Ajax.requests.count()).toBe(1);
-      expect(thirdIronApiDoiRequestResponse).toEqual('{"errors":[{"status":"404"}],"meta":{"unpaywallUsable":false}}');
+      expect(thirdIronApiDoiRequestResponse).toEqual('{"errors":[{"status":"404"}],"meta":{"avoidUnpaywall":true}}');
 
       const template = searchResult.find(".browzine");
       expect(template.length).toEqual(0);

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -4090,7 +4090,7 @@ describe("BrowZine Primo Adapter >", function() {
       //We are expecting to call our TIApi but not Unpaywall, thus we should only see one request in the jasmine ajax request queue
       const thirdIronApiDoiRequestResponse = jasmine.Ajax.requests.mostRecent().response
       expect(jasmine.Ajax.requests.count()).toBe(1);
-      expect(thirdIronApiDoiRequestResponse).toEqual('{"unpaywallUsable":false}');
+      expect(thirdIronApiDoiRequestResponse).toEqual('{"errors":[{"status":"404"}],"meta":{"unpaywallUsable":false}}');
 
       const template = searchResult.find(".browzine");
       expect(template.length).toEqual(0);

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -4043,7 +4043,7 @@ describe("BrowZine Primo Adapter >", function() {
                   },
 
                   addata: {
-                    issn: ["0028-4793"],//let's make these two unique
+                    issn: ["0089-9347"],
                     doi: ["10.35684/JLCI.2019.5202"]
                   }
                 }
@@ -4066,7 +4066,12 @@ describe("BrowZine Primo Adapter >", function() {
       thirdIronApiDoiRequest.respondWith({
         status: 404,
         response: JSON.stringify({
-          "unpaywallUsable": false
+          "errors": [{
+            "status": '404'
+          }],
+          "meta": {
+            "unpaywallUsable": false
+          }
         })
       });
     });
@@ -4083,10 +4088,8 @@ describe("BrowZine Primo Adapter >", function() {
 
     it('does not call unpaywall when unpaywallUsable=false', function () {
       //We are expecting to call our TIApi but not Unpaywall, thus we should only see one request in the jasmine ajax request queue
-      const thirdIronApiDoiRequestUrl = jasmine.Ajax.requests.mostRecent().url;
       const thirdIronApiDoiRequestResponse = jasmine.Ajax.requests.mostRecent().response
       expect(jasmine.Ajax.requests.count()).toBe(1);
-      expect(thirdIronApiDoiRequestUrl).toContain("include_suppressed=true");
       expect(thirdIronApiDoiRequestResponse).toEqual('{"unpaywallUsable":false}');
 
       const template = searchResult.find(".browzine");

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -4017,6 +4017,80 @@ describe("BrowZine Primo Adapter >", function() {
     });
   });
 
+  describe("When an article is suppressed > ", function () {
+
+    beforeEach(function() {
+      browzine.unpaywallEmailAddressKey = "info@thirdiron.com";
+      browzine.articlePDFDownloadViaUnpaywallEnabled = true;
+      browzine.articleLinkViaUnpaywallEnabled = true;
+      browzine.articleAcceptedManuscriptPDFViaUnpaywallEnabled = true;
+      browzine.articleAcceptedManuscriptArticleLinkViaUnpaywallEnabled = true;
+
+      primo = browzine.primo;
+
+      searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+      inject(function ($compile, $rootScope) {
+        $scope = $rootScope.$new();
+
+        $scope = {
+          $parent: {
+            $ctrl: {
+              result: {
+                pnx: {
+                  display: {
+                    type: ["article"]
+                  },
+
+                  addata: {
+                    issn: ["0028-4793"],//let's make these two unique
+                    doi: ["10.1136/bmj.h2575"]
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        searchResult = $compile(searchResult)($scope);
+      });
+
+      $scope.$parent.$ctrl.$element = searchResult;
+
+      jasmine.Ajax.install();
+
+      primo.searchResult($scope);
+
+      var thirdIronApiDoiRequest = jasmine.Ajax.requests.mostRecent();
+
+      thirdIronApiDoiRequest.respondWith({
+        status: 404,
+        response: JSON.stringify({
+          "unpaywallUsable": false
+        })
+      });
+    });
+
+    afterEach(function() {
+      delete browzine.unpaywallEmailAddressKey;
+      delete browzine.articlePDFDownloadViaUnpaywallEnabled;
+      delete browzine.articleLinkViaUnpaywallEnabled;
+      delete browzine.articleAcceptedManuscriptPDFViaUnpaywallEnabled;
+      delete browzine.articleAcceptedManuscriptArticleLinkViaUnpaywallEnabled;
+
+      jasmine.Ajax.uninstall();
+    });
+
+    it('does not call unpaywall when unpaywallUsable=false', function () {
+      //We are expecting to call our TIApi but not Unpaywall, thus we should only see one request in the jasmine ajax request queue
+      expect(jasmine.Ajax.requests.count()).toBe(1);
+      var template = searchResult.find(".browzine");
+      expect(template.length).toEqual(0);
+      expect(searchResult.text().trim()).not.toContain("Download PDF (via Unpaywall)");
+
+    });
+  })
+
   describe("search results without scope data >", function() {
     beforeEach(function() {
       primo = browzine.primo;

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -4083,8 +4083,13 @@ describe("BrowZine Primo Adapter >", function() {
 
     it('does not call unpaywall when unpaywallUsable=false', function () {
       //We are expecting to call our TIApi but not Unpaywall, thus we should only see one request in the jasmine ajax request queue
+      const thirdIronApiDoiRequestUrl = jasmine.Ajax.requests.mostRecent().url;
+      const thirdIronApiDoiRequestResponse = jasmine.Ajax.requests.mostRecent().response
       expect(jasmine.Ajax.requests.count()).toBe(1);
-      var template = searchResult.find(".browzine");
+      expect(thirdIronApiDoiRequestUrl).toContain("include_suppressed=true");
+      expect(thirdIronApiDoiRequestResponse).toEqual('{"unpaywallUsable":false}');
+
+      const template = searchResult.find(".browzine");
       expect(template.length).toEqual(0);
       expect(searchResult.text().trim()).not.toContain("Download PDF (via Unpaywall)");
 

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -4044,7 +4044,7 @@ describe("BrowZine Primo Adapter >", function() {
 
                   addata: {
                     issn: ["0028-4793"],//let's make these two unique
-                    doi: ["10.1136/bmj.h2575"]
+                    doi: ["10.35684/JLCI.2019.5202"]
                   }
                 }
               }

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -3468,7 +3468,7 @@ describe("BrowZine Summon Adapter >", function() {
         //We are expecting to call our TIApi but not Unpaywall, thus we should only see one request in the jasmine ajax request queue
         const thirdIronApiDoiRequestResponse = jasmine.Ajax.requests.mostRecent().response
         expect(jasmine.Ajax.requests.count()).toBe(1);
-        expect(thirdIronApiDoiRequestResponse).toEqual('{"unpaywallUsable":false}');
+        expect(thirdIronApiDoiRequestResponse).toEqual('{"errors":[{"status":"404"}],"meta":{"unpaywallUsable":false}}');
 
         const template = documentSummary.find(".browzine");
         expect(template.length).toEqual(0);

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -3412,5 +3412,60 @@ describe("BrowZine Summon Adapter >", function() {
         });
       });
     });
+
+    describe("When an article is suppressed > ", function () {
+      beforeEach(function() {
+        browzine.unpaywallEmailAddressKey = "info@thirdiron.com";
+        browzine.articlePDFDownloadViaUnpaywallEnabled = true;
+        browzine.articleLinkViaUnpaywallEnabled = true;
+        browzine.articleAcceptedManuscriptPDFViaUnpaywallEnabled = true;
+        browzine.articleAcceptedManuscriptArticleLinkViaUnpaywallEnabled = true;
+
+        summon = browzine.summon;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'><div class='availabilityContent'><div class='availabilityFullText'><span class='contentType'>Journal Article </span><a class='summonBtn' display-text='::i18n.translations.PDF'><span class='displayText'>PDF</span></a><span><a class='summonBtn'>Full Text Online</a></span></div></div></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.35684/JLCI.2019.5202"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var thirdIronApiDoiRequest = jasmine.Ajax.requests.mostRecent();
+
+        thirdIronApiDoiRequest.respondWith({
+          status: 404,
+          response: JSON.stringify({
+            "unpaywallUsable": false
+          })
+        });
+      });
+
+      afterEach(function() {
+        delete browzine.unpaywallEmailAddressKey;
+        delete browzine.articlePDFDownloadViaUnpaywallEnabled;
+        delete browzine.articleLinkViaUnpaywallEnabled;
+        delete browzine.articleAcceptedManuscriptPDFViaUnpaywallEnabled;
+        delete browzine.articleAcceptedManuscriptArticleLinkViaUnpaywallEnabled;
+
+        jasmine.Ajax.uninstall();
+      });
+      it("Does not call unpaywall when unpaywallUsable=false", function () {
+        //We are expecting to call our TIApi but not Unpaywall, thus we should only see one request in the jasmine ajax request queue
+        expect(jasmine.Ajax.requests.count()).toBe(1);
+        var template = documentSummary.find(".browzine");
+        expect(template.length).toEqual(0);
+        expect(documentSummary.text().trim()).not.toContain("Download PDF (via Unpaywall)");
+      })
+    })
   });
 });

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -3445,7 +3445,12 @@ describe("BrowZine Summon Adapter >", function() {
         thirdIronApiDoiRequest.respondWith({
           status: 404,
           response: JSON.stringify({
-            "unpaywallUsable": false
+            "errors": [{
+              "status": '404'
+            }],
+            "meta": {
+              "unpaywallUsable": false
+            }
           })
         });
       });
@@ -3461,10 +3466,8 @@ describe("BrowZine Summon Adapter >", function() {
       });
       it("Does not call unpaywall when unpaywallUsable=false", function () {
         //We are expecting to call our TIApi but not Unpaywall, thus we should only see one request in the jasmine ajax request queue
-        const thirdIronApiDoiRequestUrl = jasmine.Ajax.requests.mostRecent().url;
         const thirdIronApiDoiRequestResponse = jasmine.Ajax.requests.mostRecent().response
         expect(jasmine.Ajax.requests.count()).toBe(1);
-        expect(thirdIronApiDoiRequestUrl).toContain("include_suppressed=true");
         expect(thirdIronApiDoiRequestResponse).toEqual('{"unpaywallUsable":false}');
 
         const template = documentSummary.find(".browzine");

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -3449,7 +3449,7 @@ describe("BrowZine Summon Adapter >", function() {
               "status": '404'
             }],
             "meta": {
-              "unpaywallUsable": false
+              "avoidUnpaywall": true
             }
           })
         });
@@ -3464,11 +3464,11 @@ describe("BrowZine Summon Adapter >", function() {
 
         jasmine.Ajax.uninstall();
       });
-      it("Does not call unpaywall when unpaywallUsable=false", function () {
+      it("Does not call unpaywall when avoidUnpaywall=true", function () {
         //We are expecting to call our TIApi but not Unpaywall, thus we should only see one request in the jasmine ajax request queue
         const thirdIronApiDoiRequestResponse = jasmine.Ajax.requests.mostRecent().response
         expect(jasmine.Ajax.requests.count()).toBe(1);
-        expect(thirdIronApiDoiRequestResponse).toEqual('{"errors":[{"status":"404"}],"meta":{"unpaywallUsable":false}}');
+        expect(thirdIronApiDoiRequestResponse).toEqual('{"errors":[{"status":"404"}],"meta":{"avoidUnpaywall":true}}');
 
         const template = documentSummary.find(".browzine");
         expect(template.length).toEqual(0);

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -3461,8 +3461,13 @@ describe("BrowZine Summon Adapter >", function() {
       });
       it("Does not call unpaywall when unpaywallUsable=false", function () {
         //We are expecting to call our TIApi but not Unpaywall, thus we should only see one request in the jasmine ajax request queue
+        const thirdIronApiDoiRequestUrl = jasmine.Ajax.requests.mostRecent().url;
+        const thirdIronApiDoiRequestResponse = jasmine.Ajax.requests.mostRecent().response
         expect(jasmine.Ajax.requests.count()).toBe(1);
-        var template = documentSummary.find(".browzine");
+        expect(thirdIronApiDoiRequestUrl).toContain("include_suppressed=true");
+        expect(thirdIronApiDoiRequestResponse).toEqual('{"unpaywallUsable":false}');
+
+        const template = documentSummary.find(".browzine");
         expect(template.length).toEqual(0);
         expect(documentSummary.text().trim()).not.toContain("Download PDF (via Unpaywall)");
       })


### PR DESCRIPTION
## Summary - [BZ-8610](https://thirdiron.atlassian.net/browse/BZ-8610)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

This change allows the discovery service adapters to interpret the avoidUnpaywall variable that the TIAPI sends on some 404 returns.


## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- :warning: Depends on another PR getting into production first: CMS change must be deployed first - https://github.com/thirdiron/browzine_cms/pull/4289



[BZ-8610]: https://thirdiron.atlassian.net/browse/BZ-8610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ