### PR TITLE
Update shouldAvoidUnpaywall to avoid publisher links

### DIFF
--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -874,6 +874,8 @@ browzine.primo = (function() {
   function shouldAvoidUnpaywall(response) {
     if (response.hasOwnProperty('meta') && response.meta.hasOwnProperty('avoidUnpaywall')) {
       return response.meta.avoidUnpaywall;
+    } else if (response.data.avoidUnpaywallPublisherLinks) {
+      return true;
     } else {
       return false;
     };


### PR DESCRIPTION
## Summary - [BZ-8727](https://thirdiron.atlassian.net/browse/BZ-8727)

<!--Required: The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

This update makes it so Primo and Summons will avoid using Unpaywall Publisher Links when directed.


## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->
BEFORE"


AFTER:
![CleanShot 2024-06-24 at 16 16 01](https://github.com/thirdiron/browzine-discovery-service-adapters/assets/87537108/3540a8fc-1524-4587-ab91-191f95ecbc38)


## Implementation Notes

<!-- Optional: Any file / API changes done to accomplish the larger goal laid out in the summary.-->

1. ​

## Deploy Precautions

<!-- Required: Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- :warning: Depends on another PR getting into production first: 
- :warning: Another PR is waiting on this one to get merged:
- :warning: Has to be deployed concurrently with another system: 
- :warning: Potential to break other untested functionality in production:
- :warning: Other: 
- None
