### PR TITLE
Ignore Unpaywall response when article has "avoidUnpaywallPublisherLinks" set to true and host_type is "publisher" - bz 8727

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 360-core-loader.js
 summon-loader.js
 oneLinkSummon.js
+.vscode/settings.json

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -1019,9 +1019,9 @@ browzine.primo = (function() {
             if (requestUnpaywall.readyState == XMLHttpRequest.DONE && requestUnpaywall.status == 200) {
               var responseUnpaywall = JSON.parse(requestUnpaywall.response);
 
-              // if (shouldIgnoreUnpaywallResponse(response, responseUnpaywall)) {
-              //   return;
-              // }
+              if (shouldIgnoreUnpaywallResponse(response, responseUnpaywall)) {
+                return;
+              }
 
               var unpaywallArticlePDFUrl = getUnpaywallArticlePDFUrl(responseUnpaywall);
               var unpaywallArticleLinkUrl = getUnpaywallArticleLinkUrl(responseUnpaywall);

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -874,8 +874,6 @@ browzine.primo = (function() {
   function shouldAvoidUnpaywall(response) {
     if (response.hasOwnProperty('meta') && response.meta.hasOwnProperty('avoidUnpaywall')) {
       return response.meta.avoidUnpaywall;
-    } else if (response.hasOwnProperty('data') && response.data.hasOwnProperty('avoidUnpaywallPublisherLinks')) {
-      return response.data.avoidUnpaywallPublisherLinks;
     } else {
       return false;
     };

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -881,6 +881,15 @@ browzine.primo = (function() {
     };
   }
 
+  function shouldIgnoreUnpaywallResponse(response, unpaywallResponse) {
+    if (response.hasOwnProperty('data') && response.data.hasOwnProperty('avoidUnpaywallPublisherLinks')) {
+      if (unpaywallResponse.best_oa_location && unpaywallResponse.best_oa_location.host_type === "publisher") {
+        return true;
+      }
+    }
+    return false;
+  }
+
   function searchResult($scope) {
     var scope = getScope($scope);
 
@@ -1010,12 +1019,16 @@ browzine.primo = (function() {
 
           requestUnpaywall.onload = function() {
             if (requestUnpaywall.readyState == XMLHttpRequest.DONE && requestUnpaywall.status == 200) {
-              var response = JSON.parse(requestUnpaywall.response);
+              var responseUnpaywall = JSON.parse(requestUnpaywall.response);
 
-              var unpaywallArticlePDFUrl = getUnpaywallArticlePDFUrl(response);
-              var unpaywallArticleLinkUrl = getUnpaywallArticleLinkUrl(response);
-              var unpaywallManuscriptArticlePDFUrl = getUnpaywallManuscriptArticlePDFUrl(response);
-              var unpaywallManuscriptArticleLinkUrl = getUnpaywallManuscriptArticleLinkUrl(response);
+              if (shouldIgnoreUnpaywallResponse(response, responseUnpaywall)) {
+                return;
+              }
+
+              var unpaywallArticlePDFUrl = getUnpaywallArticlePDFUrl(responseUnpaywall);
+              var unpaywallArticleLinkUrl = getUnpaywallArticleLinkUrl(responseUnpaywall);
+              var unpaywallManuscriptArticlePDFUrl = getUnpaywallManuscriptArticlePDFUrl(responseUnpaywall);
+              var unpaywallManuscriptArticleLinkUrl = getUnpaywallManuscriptArticleLinkUrl(responseUnpaywall);
               var articleRetractionUrl = getArticleRetractionUrl(scope, data);
               var articleEocNoticeUrl = getArticleEOCNoticeUrl(scope, data);
 

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -1019,9 +1019,9 @@ browzine.primo = (function() {
             if (requestUnpaywall.readyState == XMLHttpRequest.DONE && requestUnpaywall.status == 200) {
               var responseUnpaywall = JSON.parse(requestUnpaywall.response);
 
-              if (shouldIgnoreUnpaywallResponse(response, responseUnpaywall)) {
-                return;
-              }
+              // if (shouldIgnoreUnpaywallResponse(response, responseUnpaywall)) {
+              //   return;
+              // }
 
               var unpaywallArticlePDFUrl = getUnpaywallArticlePDFUrl(responseUnpaywall);
               var unpaywallArticleLinkUrl = getUnpaywallArticleLinkUrl(responseUnpaywall);

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -1026,9 +1026,9 @@ browzine.summon = (function() {
             if (requestUnpaywall.readyState == XMLHttpRequest.DONE && requestUnpaywall.status == 200) {
               var responseUnpaywall = JSON.parse(requestUnpaywall.response);
 
-              // if (shouldIgnoreUnpaywallResponse(response, responseUnpaywall)) {
-              //   return;
-              // }
+              if (shouldIgnoreUnpaywallResponse(response, responseUnpaywall)) {
+                return;
+              }
 
               var unpaywallArticlePDFUrl = getUnpaywallArticlePDFUrl(responseUnpaywall);
               var unpaywallArticleLinkUrl = getUnpaywallArticleLinkUrl(responseUnpaywall);

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -897,6 +897,15 @@ browzine.summon = (function() {
     };
   }
 
+  function shouldIgnoreUnpaywallResponse(response, unpaywallResponse) {
+    if (response.hasOwnProperty('data') && response.data.hasOwnProperty('avoidUnpaywallPublisherLinks')) {
+      if (unpaywallResponse.best_oa_location && unpaywallResponse.best_oa_location.host_type === "publisher") {
+        return true;
+      }
+    }
+    return false;
+  }
+
   function adapter(documentSummary) {
     var scope = getScope(documentSummary);
 
@@ -1018,12 +1027,16 @@ browzine.summon = (function() {
 
           requestUnpaywall.onload = function() {
             if (requestUnpaywall.readyState == XMLHttpRequest.DONE && requestUnpaywall.status == 200) {
-              var response = JSON.parse(requestUnpaywall.response);
+              var responseUnpaywall = JSON.parse(requestUnpaywall.response);
 
-              var unpaywallArticlePDFUrl = getUnpaywallArticlePDFUrl(response);
-              var unpaywallArticleLinkUrl = getUnpaywallArticleLinkUrl(response);
-              var unpaywallManuscriptArticlePDFUrl = getUnpaywallManuscriptArticlePDFUrl(response);
-              var unpaywallManuscriptArticleLinkUrl = getUnpaywallManuscriptArticleLinkUrl(response);
+              if (shouldIgnoreUnpaywallResponse(response, responseUnpaywall)) {
+                return;
+              }
+
+              var unpaywallArticlePDFUrl = getUnpaywallArticlePDFUrl(responseUnpaywall);
+              var unpaywallArticleLinkUrl = getUnpaywallArticleLinkUrl(responseUnpaywall);
+              var unpaywallManuscriptArticlePDFUrl = getUnpaywallManuscriptArticlePDFUrl(responseUnpaywall);
+              var unpaywallManuscriptArticleLinkUrl = getUnpaywallManuscriptArticleLinkUrl(responseUnpaywall);
               var articleRetractionUrl = getArticleRetractionUrl(scope, data);
               var articleEocNoticeUrl = getArticleEOCNoticeUrl(scope, data);
 

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -889,10 +889,7 @@ browzine.summon = (function() {
   function shouldAvoidUnpaywall(response) {
     if (response.hasOwnProperty('meta') && response.meta.hasOwnProperty('avoidUnpaywall')) {
       return response.meta.avoidUnpaywall;
-    } else if (response.hasOwnProperty('data') && response.data.hasOwnProperty('avoidUnpaywallPublisherLinks')) {
-      return response.data.avoidUnpaywallPublisherLinks
-     }
-    else {
+    } else {
       return false;
     };
   }

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -1026,9 +1026,9 @@ browzine.summon = (function() {
             if (requestUnpaywall.readyState == XMLHttpRequest.DONE && requestUnpaywall.status == 200) {
               var responseUnpaywall = JSON.parse(requestUnpaywall.response);
 
-              if (shouldIgnoreUnpaywallResponse(response, responseUnpaywall)) {
-                return;
-              }
+              // if (shouldIgnoreUnpaywallResponse(response, responseUnpaywall)) {
+              //   return;
+              // }
 
               var unpaywallArticlePDFUrl = getUnpaywallArticlePDFUrl(responseUnpaywall);
               var unpaywallArticleLinkUrl = getUnpaywallArticleLinkUrl(responseUnpaywall);

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -4100,7 +4100,7 @@ describe("BrowZine Primo Adapter >", function () {
     });
   });
 
-  describe("When an article has an open access status of false and avoidUnpaywallPublisherLink = true >", function () {
+  describe("When an article has an open access status of false and avoidUnpaywallPublisherLink = true and unpaywall response has a host_type of publisher >", function () {
     beforeEach(function () {
       browzine.unpaywallEmailAddressKey = "info@thirdiron.com";
       browzine.articlePDFDownloadViaUnpaywallEnabled = true;
@@ -4208,11 +4208,33 @@ describe("BrowZine Primo Adapter >", function () {
 
       jasmine.Ajax.uninstall();
     });
-    it("Should not call unpaywall and not enhance the search result", function () {
-      //We are expecting to call our TIApi but not Unpaywall, thus we should only see one request in the jasmine ajax request queue
-      const thirdIronApiDoiRequestResponse = jasmine.Ajax.requests.mostRecent().response;
-      expect(jasmine.Ajax.requests.count()).toBe(1);
-      expect(thirdIronApiDoiRequestResponse).toContain('"avoidUnpaywallPublisherLinks":true,');
+    it("Should call unpaywall, see host_type of publisher, and not enhance the search result", function () {
+      var requestToUnpaywall = jasmine.Ajax.requests.mostRecent();
+      requestToUnpaywall.respondWith({
+        status: 200,
+        contentType: "application/json",
+        response: JSON.stringify({
+          "best_oa_location": {
+            "endpoint_id": "e32e740fde0998433a4",
+            "evidence": "oa repository (via OAI-PMH doi match)",
+            "host_type": "publisher",
+            "is_best": true,
+            "license": "cc0",
+            "pmh_id": "oai:diposit.ub.edu:2445/147225",
+            "repository_institution": "Universitat de Barcelona - Dipòsit Digital de la Universitat de Barcelona",
+            "updated": "2020-02-20T17:30:21.829852",
+            "url": "http://some.great.site/article/page",
+            "url_for_landing_page": "http://some.great.site/article/page",
+            "url_for_pdf": "http://some.great.site/article/page/stuff.pdf",
+            "version": "publishedVersion"
+          }
+        })
+      });
+
+      //We are expecting to call our TIApi and Unpaywall, so we should see two requests in the jasmine ajax request queue
+      const unpaywallApiRequestResponse = jasmine.Ajax.requests.mostRecent().response;
+      expect(jasmine.Ajax.requests.count()).toBe(2);
+      expect(unpaywallApiRequestResponse).toContain('"host_type":"publisher",');
 
       const template = searchResult.find(".browzine");
       expect(template.length).toEqual(0);

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -3476,7 +3476,7 @@ describe("BrowZine Summon Adapter >", function() {
       });
     });
 
-    describe("When an article has an open access status of false and avoidUnpaywallPublisherLink = true >", function () {
+    describe("When an article has an open access status of false and avoidUnpaywallPublisherLink = true and unpaywall response has a host_type of publisher >", function () {
       beforeEach(function () {
         browzine.unpaywallEmailAddressKey = "info@thirdiron.com";
         browzine.articlePDFDownloadViaUnpaywallEnabled = true;
@@ -3568,11 +3568,33 @@ describe("BrowZine Summon Adapter >", function() {
 
         jasmine.Ajax.uninstall();
       });
-      it("Should not call unpaywall and not enhance the search result", function () {
+      it("Should call unpaywall, see host_type of publisher, and not enhance the search result", function () {
+        var requestToUnpaywall = jasmine.Ajax.requests.mostRecent();
+        requestToUnpaywall.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "best_oa_location": {
+              "endpoint_id": "e32e740fde0998433a4",
+              "evidence": "oa repository (via OAI-PMH doi match)",
+              "host_type": "publisher",
+              "is_best": true,
+              "license": "cc0",
+              "pmh_id": "oai:diposit.ub.edu:2445/147225",
+              "repository_institution": "Universitat de Barcelona - Dipòsit Digital de la Universitat de Barcelona",
+              "updated": "2020-02-20T17:30:21.829852",
+              "url": "http://some.great.site/article/page",
+              "url_for_landing_page": "http://some.great.site/article/page",
+              "url_for_pdf": "http://some.great.site/article/page/stuff.pdf",
+              "version": "publishedVersion"
+            }
+          })
+        });
+
         //We are expecting to call our TIApi but not Unpaywall, thus we should only see one request in the jasmine ajax request queue
-        const thirdIronApiDoiRequestResponse = jasmine.Ajax.requests.mostRecent().response;
-        expect(jasmine.Ajax.requests.count()).toBe(1);
-        expect(thirdIronApiDoiRequestResponse).toContain('"avoidUnpaywallPublisherLinks":true,');
+        const unpaywallApiRequestResponse = jasmine.Ajax.requests.mostRecent().response;
+        expect(jasmine.Ajax.requests.count()).toBe(2);
+        expect(unpaywallApiRequestResponse).toContain('"host_type":"publisher",');
 
         const template = documentSummary.find(".browzine");
         expect(template.length).toEqual(0);


### PR DESCRIPTION
## Summary - [BZ-8727](https://thirdiron.atlassian.net/browse/BZ-8727)

<!--Required section. The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Correct the behavior to match the original intent

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

The epic talked about how when an article has `avoidUnpaywallPublisherLinks` set to true, we should ignore the Unpaywall API response when the `host_type` is publisher.  

This PR changes it so that, unlike the change in #134 , we will still make the Unpaywall API call when the Third Iron API's `avoidUnpaywallPublisherLinks` element is set to true.  We just won't enhance the page if Unpaywall's API indicates the best_oa_location is host_type of publisher.



## Deploy Prerequisites

<!-- Things that must be completed before deployment can safely proceed. Delete any of the items below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Precautions

<!--Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Informational Notes

<!--Things that are not concerns that would hold up a deployment or shape how a deployment is executed, but may be useful to know about when preparing for a deployment or after a deployment is completed. Delete any of the notices below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None



[BZ-8727]: https://thirdiron.atlassian.net/browse/BZ-8727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ