### PR TITLE
Add problematic journal support - bz 7970

### DIFF
--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -579,7 +579,7 @@ browzine.primo = (function() {
       pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
       pdfIconWidth = "15";
       pdfIconMarginRight = "1.5px";
-      articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "Problematic Journal";
+      articlePDFDownloadLinkText = browzine.problematicJournalText || "Problematic Journal";
     }
 
     var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
@@ -619,10 +619,10 @@ browzine.primo = (function() {
       articleLinkText = browzine.articleExpressionOfConcernText || "Expression of Concern";
     } else if (showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl)) {
       articleLinkUrl = problematicJournalArticleNoticeUrl;
-      pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
-      pdfIconWidth = "15";
-      pdfIconMarginRight = "1.5px";
-      articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "Problematic Journal";
+      linkIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
+      linkIconWidth = "15";
+      linkIconMarginRight = "1.5px";
+      articleLinkText = browzine.problematicJournalText || "Problematic Journal";
     }
 
     var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
@@ -765,7 +765,7 @@ browzine.primo = (function() {
       pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
       pdfIconWidth = "15";
       pdfIconMarginRight = "1.5px";
-      articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "Problematic Journal";
+      articlePDFDownloadLinkText = browzine.problematicJournalText || "Problematic Journal";
     }
 
     var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
@@ -828,7 +828,7 @@ browzine.primo = (function() {
       pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
       pdfIconWidth = "15";
       pdfIconMarginRight = "1.5px";
-      articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "Problematic Journal";
+      articlePDFDownloadLinkText = browzine.problematicJournalText || "Problematic Journal";
     }
 
     var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -1008,7 +1008,7 @@ browzine.primo = (function() {
           libKeyLinkOptimizer.innerHTML += template;
         }
 
-        if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && !articleEocNoticeUrl && problematicJournalArticleNoticeUrl && isArticle(scope) && showExpressionOfConcern()) {
+        if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && !articleEocNoticeUrl && problematicJournalArticleNoticeUrl && isArticle(scope)) {
           var template = problematicJournalArticleNoticeLinkTemplate(problematicJournalArticleNoticeUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -289,6 +289,17 @@ browzine.primo = (function() {
     return articleEocNoticeUrl;
   }
 
+  function getProblematicJournalArticleNoticeUrl(scope, data) {
+    var problematicJournalArticleNoticeUrl = null;
+
+    if (isArticle(scope)) {
+      if (data && data.problematicJournalArticleNoticeUrl) {
+        problematicJournalArticleNoticeUrl = data.problematicJournalArticleNoticeUrl;
+      }
+    }
+    return problematicJournalArticleNoticeUrl;
+  }
+
   function isTrustedRepository(response) {
     var validation = false;
 
@@ -541,7 +552,11 @@ browzine.primo = (function() {
     return articleEocNoticeUrl && showExpressionOfConcern();
   }
 
-  function directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl) {
+  function showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl) {
+    return !!problematicJournalArticleNoticeUrl;
+  }
+
+  function directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
     var pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-pdf-download-icon.svg";
     var pdfIconWidth = "12";
     var pdfIconMarginRight = "4.5px";
@@ -559,6 +574,12 @@ browzine.primo = (function() {
       pdfIconWidth = "15";
       pdfIconMarginRight = "1.5px";
       articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "Expression of Concern";
+    } else if (showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl)) {
+      directToPDFUrl = problematicJournalArticleNoticeUrl;
+      pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
+      pdfIconWidth = "15";
+      pdfIconMarginRight = "1.5px";
+      articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "Problematic Journal";
     }
 
     var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
@@ -578,7 +599,7 @@ browzine.primo = (function() {
     return template;
   };
 
-  function articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl) {
+  function articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
     var linkIcon = "https://assets.thirdiron.com/images/integrations/browzine-article-link-icon.svg";
     var linkIconWidth = "12";
     var linkIconMarginRight = "4.5px";
@@ -596,6 +617,12 @@ browzine.primo = (function() {
       linkIconWidth = "15";
       linkIconMarginRight = "1.5px";
       articleLinkText = browzine.articleExpressionOfConcernText || "Expression of Concern";
+    } else if (showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl)) {
+      articleLinkUrl = problematicJournalArticleNoticeUrl;
+      pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
+      pdfIconWidth = "15";
+      pdfIconMarginRight = "1.5px";
+      articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "Problematic Journal";
     }
 
     var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
@@ -663,6 +690,30 @@ browzine.primo = (function() {
     return template;
   };
 
+  function problematicJournalArticleNoticeLinkTemplate(problematicJournalArticleNoticeUrl) {
+    var articleLinkUrl = problematicJournalArticleNoticeUrl;
+    var linkIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
+    var linkIconWidth = "15";
+    var linkIconMarginRight = "1.5px";
+    var articleLinkText = browzine.problematicJournalText || "Problematic Journal";
+
+    var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
+                      "<a class='browzine-article-link' href='{articleLinkUrl}' target='_blank' onclick='browzine.primo.transition(event, this)'>" +
+                          "<img alt='BrowZine Article Link Icon' src='{linkIcon}' class='browzine-article-link-icon' style='margin-bottom: -3px; margin-right: {linkIconMarginRight};' aria-hidden='true' width='{linkIconWidth}' height='16'/> " +
+                          "<span class='browzine-article-link-text'>{articleLinkText}</span> " +
+                          "<md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon>" +
+                      "</a>" +
+                   "</div>";
+
+    template = template.replace(/{articleLinkUrl}/g, articleLinkUrl);
+    template = template.replace(/{articleLinkText}/g, articleLinkText);
+    template = template.replace(/{linkIcon}/g, linkIcon);
+    template = template.replace(/{linkIconWidth}/g, linkIconWidth);
+    template = template.replace(/{linkIconMarginRight}/g, linkIconMarginRight);
+
+    return template;
+  };
+
 
   function browzineWebLinkTemplate(scope, browzineWebLink) {
     var browzineWebLinkText = "";
@@ -691,7 +742,7 @@ browzine.primo = (function() {
     return template;
   };
 
-  function unpaywallArticlePDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl) {
+  function unpaywallArticlePDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
     var pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-pdf-download-icon.svg";
     var pdfIconWidth = "12";
     var pdfIconMarginRight = "4.5px";
@@ -709,6 +760,12 @@ browzine.primo = (function() {
       pdfIconWidth = "15";
       pdfIconMarginRight = "1.5px";
       articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "Expression of Concern";
+    } else if (showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl)) {
+      directToPDFUrl = problematicJournalArticleNoticeUrl;
+      pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
+      pdfIconWidth = "15";
+      pdfIconMarginRight = "1.5px";
+      articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "Problematic Journal";
     }
 
     var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
@@ -748,7 +805,7 @@ browzine.primo = (function() {
     return template;
   };
 
-  function unpaywallManuscriptPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl) {
+  function unpaywallManuscriptPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
     var pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-pdf-download-icon.svg";
     var pdfIconWidth = "12";
     var pdfIconMarginRight = "4.5px";
@@ -766,6 +823,12 @@ browzine.primo = (function() {
       pdfIconWidth = "15";
       pdfIconMarginRight = "1.5px";
       articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "Expression of Concern";
+    } else if (showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl)) {
+      articleLinkUrl = problematicJournalArticleNoticeUrl;
+      pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg";
+      pdfIconWidth = "15";
+      pdfIconMarginRight = "1.5px";
+      articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "Problematic Journal";
     }
 
     var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
@@ -917,6 +980,7 @@ browzine.primo = (function() {
         var articleLinkUrl = getArticleLinkUrl(scope, data);
         var articleRetractionUrl = getArticleRetractionUrl(scope, data);
         var articleEocNoticeUrl = getArticleEOCNoticeUrl(scope, data);
+        var problematicJournalArticleNoticeUrl = getProblematicJournalArticleNoticeUrl(scope, data);
 
         var element = getElement(scope);
 
@@ -925,12 +989,12 @@ browzine.primo = (function() {
         libKeyLinkOptimizer.style = "display: flex; justify-content: flex-start;";
 
         if (directToPDFUrl && isArticle(scope) && showDirectToPDFLink()) {
-          var template = directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl);
+          var template = directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 
-        if ((!directToPDFUrl || (showFormatChoice() && !articleRetractionUrl && !articleEocNoticeUrl)) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
-          var template = articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl);
+        if ((!directToPDFUrl || (showFormatChoice() && !articleRetractionUrl && !articleEocNoticeUrl && !problematicJournalArticleNoticeUrl)) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
+          var template = articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 
@@ -941,6 +1005,11 @@ browzine.primo = (function() {
 
         if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && articleEocNoticeUrl && isArticle(scope) && showExpressionOfConcern()) {
           var template = eocLinkTemplate(articleEocNoticeUrl);
+          libKeyLinkOptimizer.innerHTML += template;
+        }
+
+        if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && !articleEocNoticeUrl && problematicJournalArticleNoticeUrl && isArticle(scope) && showExpressionOfConcern()) {
+          var template = problematicJournalArticleNoticeLinkTemplate(problematicJournalArticleNoticeUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 
@@ -1029,17 +1098,18 @@ browzine.primo = (function() {
               var unpaywallManuscriptArticleLinkUrl = getUnpaywallManuscriptArticleLinkUrl(responseUnpaywall);
               var articleRetractionUrl = getArticleRetractionUrl(scope, data);
               var articleEocNoticeUrl = getArticleEOCNoticeUrl(scope, data);
+              var problematicJournalArticleNoticeUrl = getProblematicJournalArticleNoticeUrl(scope, data);
 
               var template;
               var pdfAvailable = false;
 
               if (unpaywallArticlePDFUrl && browzine.articlePDFDownloadViaUnpaywallEnabled) {
-                template = unpaywallArticlePDFTemplate(unpaywallArticlePDFUrl, articleRetractionUrl, articleEocNoticeUrl);
+                template = unpaywallArticlePDFTemplate(unpaywallArticlePDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl);
                 pdfAvailable = true;
               } else if (unpaywallArticleLinkUrl && browzine.articleLinkViaUnpaywallEnabled ) {
                 template = unpaywallArticleLinkTemplate(unpaywallArticleLinkUrl);
               } else if (unpaywallManuscriptArticlePDFUrl && browzine.articleAcceptedManuscriptPDFViaUnpaywallEnabled) {
-                template = unpaywallManuscriptPDFTemplate(unpaywallManuscriptArticlePDFUrl, articleRetractionUrl, articleEocNoticeUrl);
+                template = unpaywallManuscriptPDFTemplate(unpaywallManuscriptArticlePDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl);
                 pdfAvailable = true;
               } else if (unpaywallManuscriptArticleLinkUrl && browzine.articleAcceptedManuscriptArticleLinkViaUnpaywallEnabled) {
                 template = unpaywallManuscriptLinkTemplate(unpaywallManuscriptArticleLinkUrl);

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -1013,7 +1013,7 @@ browzine.summon = (function() {
           libKeyLinkOptimizer.innerHTML += template;
         }
 
-        if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && !articleEocNoticeUrl && problematicJournalArticleNoticeUrl && isArticle(scope) && showExpressionOfConcern()) {
+        if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && !articleEocNoticeUrl && problematicJournalArticleNoticeUrl && isArticle(scope)) {
           var template = problematicJournalArticleNoticeLinkTemplate(problematicJournalArticleNoticeUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -277,6 +277,17 @@ browzine.summon = (function() {
     return articleEocNoticeUrl;
   }
 
+  function getProblematicJournalArticleNoticeUrl(scope, data) {
+    var problematicJournalArticleNoticeUrl = null;
+
+    if (isArticle(scope)) {
+      if (data && data.problematicJournalArticleNoticeUrl) {
+        problematicJournalArticleNoticeUrl = data.problematicJournalArticleNoticeUrl;
+      }
+    }
+    return problematicJournalArticleNoticeUrl;
+  }
+
   function getPdfIconSvg() {
     var color = browzine.iconColor || "#639add";
 
@@ -558,7 +569,11 @@ browzine.summon = (function() {
     return articleEocNoticeUrl && showExpressionOfConcern();
   }
 
-  function directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl) {
+  function showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl) {
+    return !!problematicJournalArticleNoticeUrl;
+  }
+
+  function directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
     var pdfIcon = getPdfIconSvg();
     var pdfIconWidth = "13";
 
@@ -580,6 +595,11 @@ browzine.summon = (function() {
       pdfIcon = getRetractionWatchIconSvg();
       articlePDFDownloadWording = browzine.articleExpressionOfConcernWording || "Expression of Concern";
       articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "More Info";
+    } else if (showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl)) {
+      directToPDFUrl = problematicJournalArticleNoticeUrl;
+      pdfIcon = getRetractionWatchIconSvg();
+      articlePDFDownloadWording = browzine.problematicJournalWording || "Problematic Journal";
+      articlePDFDownloadLinkText = browzine.problematicJournalText || "More Info";
     }
 
     var template = "<div class='browzine'>" +
@@ -596,7 +616,7 @@ browzine.summon = (function() {
     return template;
   };
 
-  function articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl) {
+  function articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
     var paperIcon = getPaperIconSvg();
 
     var articleLinkTextWording = "View Now";
@@ -617,6 +637,11 @@ browzine.summon = (function() {
       pdfIcon = getRetractionWatchIconSvg();
       articleLinkTextWording = browzine.articleExpressionOfConcernWording || "Expression of Concern";
       articleLinkText = browzine.articleExpressionOfConcernText || "More Info";
+    } else if (showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl)) {
+      articleLinkUrl = problematicJournalArticleNoticeUrl;
+      pdfIcon = getRetractionWatchIconSvg();
+      articlePDFDownloadWording = browzine.problematicJournalWording || "Problematic Journal";
+      articlePDFDownloadLinkText = browzine.problematicJournalText || "More Info";
     }
 
     var template = "<div class='browzine'>" +
@@ -677,6 +702,26 @@ browzine.summon = (function() {
     return template;
   };
 
+  function problematicJournalArticleNoticeLinkTemplate(problematicJournalArticleNoticeUrl) {
+    var articleLinkUrl = problematicJournalArticleNoticeUrl;
+    var paperIcon = getRetractionWatchIconSvg();
+
+   var articleLinkTextWording = browzine.problematicJournalWording || "Problematic Journal";
+   var articleLinkText = browzine.problematicJournalText || "More Info";
+
+    var template = "<div class='browzine'>" +
+      "<span class='contentType' style='margin-right: 4.5px;'>{articleLinkTextWording}</span>" +
+      "<a class='browzine-article-link summonBtn customPrimaryLink' href='{articleLinkUrl}' target='_blank' onclick='browzine.summon.transition(event, this)'>{paperIcon}<span style='margin-left: 0px;'>{articleLinkText}</span></a>" +
+    "</div>";
+
+    template = template.replace(/{articleLinkTextWording}/g, articleLinkTextWording);
+    template = template.replace(/{articleLinkUrl}/g, articleLinkUrl);
+    template = template.replace(/{articleLinkText}/g, articleLinkText);
+    template = template.replace(/{paperIcon}/g, paperIcon);
+
+    return template;
+  };
+
   function browzineWebLinkTemplate(scope, browzineWebLink) {
     var wording = "";
     var browzineWebLinkText = "";
@@ -714,7 +759,7 @@ browzine.summon = (function() {
     return template;
   };
 
-  function unpaywallArticlePDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl) {
+  function unpaywallArticlePDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
     var pdfIcon = getPdfIconSvg();
     var pdfIconWidth = "13";
 
@@ -736,6 +781,11 @@ browzine.summon = (function() {
       pdfIcon = getRetractionWatchIconSvg();
       articlePDFDownloadWording = browzine.articleExpressionOfConcernWording || "Expression of Concern";
       articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "More Info";
+    } else if (showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl)) {
+      directToPDFUrl = problematicJournalArticleNoticeUrl;
+      pdfIcon = getRetractionWatchIconSvg();
+      articlePDFDownloadWording = browzine.problematicJournalWording || "Problematic Journal";
+      articlePDFDownloadLinkText = browzine.problematicJournalText || "More Info";
     }
 
     var template = "<div class='browzine'>" +
@@ -775,7 +825,7 @@ browzine.summon = (function() {
     return template;
   };
 
-  function unpaywallManuscriptPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl) {
+  function unpaywallManuscriptPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
     var pdfIcon = getPdfIconSvg();
     var pdfIconWidth = "13";
 
@@ -797,6 +847,11 @@ browzine.summon = (function() {
       pdfIcon = getRetractionWatchIconSvg();
       articlePDFDownloadWording = browzine.articleExpressionOfConcernWording || "Expression of Concern";
       articlePDFDownloadLinkText = browzine.articleExpressionOfConcernText || "More Info";
+    } else if (showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl)) {
+      directToPDFUrl = problematicJournalArticleNoticeUrl;
+      pdfIcon = getRetractionWatchIconSvg();
+      articlePDFDownloadWording = browzine.problematicJournalWording || "Problematic Journal";
+      articlePDFDownloadLinkText = browzine.problematicJournalText || "More Info";
     }
 
     var template = "<div class='browzine'>" +
@@ -931,6 +986,7 @@ browzine.summon = (function() {
         var articleLinkUrl = getArticleLinkUrl(scope, data);
         var articleRetractionUrl = getArticleRetractionUrl(scope, data);
         var articleEocNoticeUrl = getArticleEOCNoticeUrl(scope, data);
+        var problematicJournalArticleNoticeUrl = getProblematicJournalArticleNoticeUrl(scope, data);
         var unpaywallUsable = getUnpaywallUsable(scope, data);
 
         var libKeyLinkOptimizer = document.createElement("div");
@@ -956,6 +1012,13 @@ browzine.summon = (function() {
           var template = eocLinkTemplate(articleEocNoticeUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
+
+        if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && !articleEocNoticeUrl && problematicJournalArticleNoticeUrl && isArticle(scope) && showExpressionOfConcern()) {
+          var template = problematicJournalArticleNoticeLinkTemplate(problematicJournalArticleNoticeUrl);
+          libKeyLinkOptimizer.innerHTML += template;
+        }
+
+
 
         if (libKeyLinkOptimizer.innerHTML) {
           var secondaryTitle = libKeyLinkOptimizer.querySelector(".browzine:nth-child(2) .contentType");
@@ -1036,17 +1099,18 @@ browzine.summon = (function() {
               var unpaywallManuscriptArticleLinkUrl = getUnpaywallManuscriptArticleLinkUrl(responseUnpaywall);
               var articleRetractionUrl = getArticleRetractionUrl(scope, data);
               var articleEocNoticeUrl = getArticleEOCNoticeUrl(scope, data);
+              var problematicJournalArticleNoticeUrl = getProblematicJournalArticleNoticeUrl(scope, data);
 
               var template;
               var pdfAvailable = false;
 
               if (unpaywallArticlePDFUrl && browzine.articlePDFDownloadViaUnpaywallEnabled) {
-                template = unpaywallArticlePDFTemplate(unpaywallArticlePDFUrl, articleRetractionUrl, articleEocNoticeUrl);
+                template = unpaywallArticlePDFTemplate(unpaywallArticlePDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl);
                 pdfAvailable = true;
               } else if (unpaywallArticleLinkUrl && browzine.articleLinkViaUnpaywallEnabled ) {
                 template = unpaywallArticleLinkTemplate(unpaywallArticleLinkUrl);
               } else if (unpaywallManuscriptArticlePDFUrl && browzine.articleAcceptedManuscriptPDFViaUnpaywallEnabled) {
-                template = unpaywallManuscriptPDFTemplate(unpaywallManuscriptArticlePDFUrl, articleRetractionUrl, articleEocNoticeUrl);
+                template = unpaywallManuscriptPDFTemplate(unpaywallManuscriptArticlePDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl);
                 pdfAvailable = true;
               } else if (unpaywallManuscriptArticleLinkUrl && browzine.articleAcceptedManuscriptArticleLinkViaUnpaywallEnabled) {
                 template = unpaywallManuscriptLinkTemplate(unpaywallManuscriptArticleLinkUrl);

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -640,8 +640,8 @@ browzine.summon = (function() {
     } else if (showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl)) {
       articleLinkUrl = problematicJournalArticleNoticeUrl;
       pdfIcon = getRetractionWatchIconSvg();
-      articlePDFDownloadWording = browzine.problematicJournalWording || "Problematic Journal";
-      articlePDFDownloadLinkText = browzine.problematicJournalText || "More Info";
+      articleLinkTextWording = browzine.problematicJournalWording || "Problematic Journal";
+      articleLinkText = browzine.problematicJournalText || "More Info";
     }
 
     var template = "<div class='browzine'>" +
@@ -994,12 +994,12 @@ browzine.summon = (function() {
         libKeyLinkOptimizer.style = "display: flex; justify-content: flex-start;";
 
         if (directToPDFUrl && isArticle(scope) && showDirectToPDFLink()) {
-          var template = directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl);
+          var template = directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 
         if ((!directToPDFUrl || (showFormatChoice() && !articleRetractionUrl && !articleEocNoticeUrl)) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
-          var template = articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl);
+          var template = articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -689,6 +689,139 @@ describe("BrowZine Primo Adapter >", function () {
       });
     });
 
+    describe("search results article with both browzine web link and problematic journal notice link >", function () {
+      beforeEach(function () {
+        primo = browzine.primo;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["1538-3598"],
+                      doi: ["10.1001/jama.298.4.413"]
+                    }
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$parent.$ctrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 4699582,
+              "type": "articles",
+              "title": "Retracted: Science Based on Pencil Sketches",
+              "date": "2007-05-13",
+              "authors": "Kiel, Douglas P.; Magaziner, Jay; Zimmerman, Sheryl; Birge, Stanley J.",
+              "inPress": false,
+              "doi": "10.1001/jama.298.4.413",
+              "openAccess": true,
+              "fullTextFile": "https://develop.libkey.io/libraries/XXXX/articles/4699582/full-text-file?utm_source=api_716",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/4699582/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "413",
+              "endPage": "",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/10278/issues/4699582?showArticleInContext=doi:10.1001%2Fjama.298.4.413&utm_source=api_716",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 10278
+                  }
+                }
+              },
+              "problematicJournalArticleNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1001/jama.298.4.413.problematic",
+            },
+            "included": [
+              {
+                "id": 10278,
+                "type": "journals",
+                "title": "JAMA: Journal of the American Medical Association",
+                "issn": "15383598",
+                "sjrValue": 6.695,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1538-3598.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/10278?utm_source=api_716"
+              }
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1001%2Fjama.298.4.413/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function () {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should have an enhanced browse article in browzine option", function () {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).toContain("Problematic Journal");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/10278/issues/4699582?showArticleInContext=doi:10.1001%2Fjama.298.4.413&utm_source=api_716");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.svg");
+
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1001/jama.298.4.413.problematic");
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function (done) {
+        requestAnimationFrame(function () {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function (coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/1538-3598.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when a problematic journal article notice link is clicked", function () {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-direct-to-pdf-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1001/jama.298.4.413.problematic", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function () {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/10278/issues/4699582?showArticleInContext=doi:10.1001%2Fjama.298.4.413&utm_source=api_716", "_blank");
+      });
+    });
+
     describe("retraction notice and only an article link >", function () {
       beforeEach(function () {
         primo = browzine.primo;
@@ -963,6 +1096,139 @@ describe("BrowZine Primo Adapter >", function () {
       });
     });
 
+    describe("problematic journal notice and only an article link >", function () {
+      beforeEach(function () {
+        primo = browzine.primo;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["10837159"],
+                      doi: ["10.1634/theoncologist.8-4-307"]
+                    }
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$parent.$ctrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "problematicJournalArticleNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic",
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function () {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show problematic journal notices when there is only an article link", function () {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).toContain("Problematic Journal");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.svg");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-article-link-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function (done) {
+        requestAnimationFrame(function () {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function (coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/1083-7159.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when a problematic journal article notice link is clicked", function () {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function () {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572", "_blank");
+      });
+    });
+
     describe("retraction notice and no pdf link or article link >", function () {
       beforeEach(function () {
         primo = browzine.primo;
@@ -1211,6 +1477,128 @@ describe("BrowZine Primo Adapter >", function () {
         spyOn(window, "open");
         searchResult.find(".browzine .browzine-article-link").click();
         expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307", "_blank");
+      });
+    });
+
+    describe("problematic journal notice and no pdf link or article link >", function () {
+      beforeEach(function () {
+        primo = browzine.primo;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["10837159"],
+                      doi: ["10.1634/theoncologist.8-4-307"]
+                    }
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$parent.$ctrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "",
+              "availableThroughBrowzine": false,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "problematicJournalArticleNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic",
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function () {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show problematic journal notices when available even if no pdf link or article link available", function () {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("Problematic Journal");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-article-link-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function (done) {
+        requestAnimationFrame(function () {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function (coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/1083-7159.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when a problematic journal article notice link is clicked", function () {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic", "_blank");
       });
     });
 
@@ -1483,6 +1871,144 @@ describe("BrowZine Primo Adapter >", function () {
         spyOn(window, "open");
         searchResult.find(".browzine .browzine-direct-to-pdf-link").click();
         expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function () {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/13016/issues/4629899?showArticleInContext=doi:10.1002%2Fijc.25451&utm_source=api_716", "_blank");
+      });
+    });
+
+    describe("search results article with both problematic journal notice link and article link >", function () {
+      beforeEach(function () {
+        primo = browzine.primo;
+        browzine.showFormatChoice = true;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["0020-7136"],
+                      doi: ["10.1002/ijc.25451"]
+                    }
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$parent.$ctrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 26652324,
+              "type": "articles",
+              "title": "A tritherapy combination of a fusion protein vaccine with immune‐modulating doses of sequential chemotherapies in an optimized regimen completely eradicates large tumors in mice",
+              "date": "2010-05-12",
+              "authors": "Song, Xinxin; Guo, Wenzhong; Cui, Jianfeng; Qian, Xinlai; Yi, Linan; Chang, Mengjiao; Cai, Qiliang; Zhao, Qingzheng",
+              "inPress": false,
+              "doi": "10.1002/ijc.25451",
+              "ILLURL": "",
+              "pmid": "",
+              "openAccess": true,
+              "fullTextFile": "https://develop.libkey.io/libraries/XXXX/articles/26652324/full-text-file?utm_source=api_716",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/26652324/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "326",
+              "endPage": "",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/13016/issues/4629899?showArticleInContext=doi:10.1002%2Fijc.25451&utm_source=api_716",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 13016
+                  }
+                }
+              },
+              "problematicJournalArticleNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451.problematic"
+            },
+            "included": [
+              {
+                "id": 13016,
+                "type": "journals",
+                "title": "International Journal of Cancer",
+                "issn": "00207136",
+                "sjrValue": 2.259,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/0020-7136.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/13016?utm_source=api_716"
+              }
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1002%2Fijc.25451/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function () {
+        jasmine.Ajax.uninstall();
+        delete browzine.showFormatChoice;
+      });
+
+      it("should have an enhanced browse article showing problematic journal only", function () {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).toContain("Problematic Journal");
+        expect(template.text().trim()).not.toContain("Read Article");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/13016/issues/4629899?showArticleInContext=doi:10.1002%2Fijc.25451&utm_source=api_716");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.svg");
+
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451.problematic");
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-pdf-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-retraction-watch-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function (done) {
+        requestAnimationFrame(function () {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function (coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/0020-7136.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when a problematic journal article notice link is clicked", function () {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-direct-to-pdf-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451.problematic", "_blank");
       });
 
       it("should open a new window when a browzine web link is clicked", function () {

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -461,6 +461,116 @@ describe("BrowZine Summon Adapter >", function() {
       });
     });
 
+    describe("search results article with both browzine web link and problematic journal notice link >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1001/jama.298.4.413"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 4699582,
+              "type": "articles",
+              "title": "Efficacy of a Hip Protector to Prevent Hip Fracture in Nursing Home Residents",
+              "date": "2007-05-13",
+              "authors": "Kiel, Douglas P.; Magaziner, Jay; Zimmerman, Sheryl; Birge, Stanley J.",
+              "inPress": false,
+              "doi": "10.1001/jama.298.4.413",
+              "openAccess": true,
+              "fullTextFile": "https://develop.libkey.io/libraries/XXXX/articles/4699582/full-text-file?utm_source=api_716",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/4699582/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "413",
+              "endPage": "",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/10278/issues/4699582?showArticleInContext=doi:10.1001%2Fjama.298.4.413&utm_source=api_716",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 10278
+                  }
+                }
+              },
+              "problematicJournalArticleNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1001/jama.298.4.413.problematic"
+            },
+            "included": [
+              {
+                "id": 10278,
+                "type": "journals",
+                "title": "JAMA: Journal of the American Medical Association",
+                "issn": "15383598",
+                "sjrValue": 6.695,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1538-3598.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/10278?utm_source=api_716"
+              }
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1001%2Fjama.298.4.413/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should have an enhanced browse article in browzine option", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View in Context Browse Journal");
+        expect(template.text().trim()).toContain("Problematic Journal More Info");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/10278/issues/4699582?showArticleInContext=doi:10.1001%2Fjama.298.4.413&utm_source=api_716");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1001/jama.298.4.413.problematic");
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+        expect(template.find("svg.browzine-pdf-icon")).toBeDefined();
+      });
+
+      it("should have an enhanced browzine journal cover", function() {
+        var coverImage = documentSummary.find(".coverImage img");
+        expect(coverImage).toBeDefined();
+        expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/1538-3598.png");
+      });
+
+      it("should open a new window when a problematic journal article notice link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-direct-to-pdf-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1001/jama.298.4.413.problematic", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/10278/issues/4699582?showArticleInContext=doi:10.1001%2Fjama.298.4.413&utm_source=api_716", "_blank");
+      });
+    });
+
     describe("retraction notice and only an article link >", function() {
       beforeEach(function() {
         summon = browzine.summon;
@@ -688,6 +798,115 @@ describe("BrowZine Summon Adapter >", function() {
       });
     });
 
+    describe("problematic journal notice and only an article link >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1634/theoncologist.8-4-307"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "problematicJournalArticleNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic"
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show problematic journal article notices when there is only an article link", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View in Context Browse Journal");
+        expect(template.text().trim()).toContain("Problematic Journal More Info");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+      });
+
+      it("should have an enhanced browzine journal cover", function() {
+        var coverImage = documentSummary.find(".coverImage img");
+        expect(coverImage).toBeDefined();
+        expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/1083-7159.png");
+      });
+
+      it("should open a new window when a problematic journal article notice link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572", "_blank");
+      });
+    });
+
     describe("retraction notice and no pdf link or article link >", function() {
       beforeEach(function() {
         summon = browzine.summon;
@@ -890,6 +1109,105 @@ describe("BrowZine Summon Adapter >", function() {
         spyOn(window, "open");
         documentSummary.find(".browzine .browzine-article-link").click();
         expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307", "_blank");
+      });
+    });
+
+    describe("problematic journal notice and no pdf link or article link >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1634/theoncologist.8-4-307"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "",
+              "availableThroughBrowzine": false,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "problematicJournalArticleNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic"
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show problematic journal notices when available even if no pdf link or article link available", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("Problematic Journal More Info");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+      });
+
+      it("should have an enhanced browzine journal cover", function() {
+        var coverImage = documentSummary.find(".coverImage img");
+        expect(coverImage).toBeDefined();
+        expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/1083-7159.png");
+      });
+
+      it("should open a new window when a problematic journal article notice link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic", "_blank");
       });
     });
 
@@ -1116,6 +1434,121 @@ describe("BrowZine Summon Adapter >", function() {
         spyOn(window, "open");
         documentSummary.find(".browzine .browzine-direct-to-pdf-link").click();
         expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/13016/issues/4629899?showArticleInContext=doi:10.1002%2Fijc.25451&utm_source=api_716", "_blank");
+      });
+    });
+
+    describe("search results article with both problematic journal notice link and article link >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+        browzine.showFormatChoice = true;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1002/ijc.25451"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 26652324,
+              "type": "articles",
+              "title": "A tritherapy combination of a fusion protein vaccine with immune‐modulating doses of sequential chemotherapies in an optimized regimen completely eradicates large tumors in mice",
+              "date": "2010-05-12",
+              "authors": "Song, Xinxin; Guo, Wenzhong; Cui, Jianfeng; Qian, Xinlai; Yi, Linan; Chang, Mengjiao; Cai, Qiliang; Zhao, Qingzheng",
+              "inPress": false,
+              "doi": "10.1002/ijc.25451",
+              "ILLURL": "",
+              "pmid": "",
+              "openAccess": true,
+              "fullTextFile": "https://develop.libkey.io/libraries/XXXX/articles/26652324/full-text-file?utm_source=api_716",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/26652324/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "326",
+              "endPage": "",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/13016/issues/4629899?showArticleInContext=doi:10.1002%2Fijc.25451&utm_source=api_716",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 13016
+                  }
+                }
+              },
+              "problematicJournalArticleNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451.problematic"
+            },
+            "included": [
+              {
+                "id": 13016,
+                "type": "journals",
+                "title": "International Journal of Cancer",
+                "issn": "00207136",
+                "sjrValue": 2.259,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/0020-7136.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/13016?utm_source=api_716"
+              }
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1002%2Fijc.25451/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+        delete browzine.showFormatChoice;
+      });
+
+      it("should have an enhanced browse article showing problematic journal article notice only", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View in Context Browse Journal");
+        expect(template.text().trim()).toContain("Problematic Journal More Info");
+        expect(template.text().trim()).not.toContain("Article Page");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/13016/issues/4629899?showArticleInContext=doi:10.1002%2Fijc.25451&utm_source=api_716");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451.problematic");
+        expect(template.find("a.browzine-direct-to-pdf-link").attr("target")).toEqual("_blank");
+        expect(template.find("svg.browzine-pdf-icon")).toBeDefined();
+      });
+
+      it("should have an enhanced browzine journal cover", function() {
+        var coverImage = documentSummary.find(".coverImage img");
+        expect(coverImage).toBeDefined();
+        expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/0020-7136.png");
+      });
+
+      it("should open a new window when a problematic journal article notice link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-direct-to-pdf-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1002/ijc.25451.problematic", "_blank");
       });
 
       it("should open a new window when a browzine web link is clicked", function() {


### PR DESCRIPTION
## Summary - [BZ-7970](https://thirdiron.atlassian.net/browse/BZ-7970)

<!--Required section. The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Add support for identifying articles that belong to problematic journals

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

This allows problematic journal data to be displayed in Primo or Summon.

I've added basic tests that are very similar to the tests made for Expressions of Concern.

One test I didn't bother to add: what happens if an article has both an EOC and is in a problematic journal.  If this happens, EOC should take priority, but I didn't specifically add a test... and I'm not sure it matters because one way or another, the Discovery Service Adapter should display something out of the ordinary beyond it being a typical article.  Think that's OK?


## Deploy Prerequisites

<!-- Things that must be completed before deployment can safely proceed. Delete any of the items below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Precautions

<!--Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Informational Notes

<!--Things that are not concerns that would hold up a deployment or shape how a deployment is executed, but may be useful to know about when preparing for a deployment or after a deployment is completed. Delete any of the notices below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None



[BZ-7970]: https://thirdiron.atlassian.net/browse/BZ-7970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ