### PR TITLE
Update release notes generator container to node 18 LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
             npm run deploy-primo-master
   renogen:
     docker:
-      - image: cimg/node:12.18
+      - image: cimg/node:18.16.1
     steps:
       - add_ssh_keys
       - run:


### PR DESCRIPTION
## Summary - [BZ-7902](https://thirdiron.atlassian.net/browse/BZ-7902)

This PR updates the CircleCI config to run the release notes generator in a node 18 LTS container

## Deploy Prerequisites

- None

## Deploy Precautions

- None

## Deploy Informational Notes

- None



[BZ-7902]: https://thirdiron.atlassian.net/browse/BZ-7902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ