### PR TITLE
Problematic Journal label customization - bz 9521

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ var browzine = {
   articleExpressionOfConcernWording: "Expression of Concern",
   articleExpressionOfConcernText: "More Info",
 
+  problematicJournalEnabled: true,
   problematicJournalWording: "Problematic Journal",
   problematicJournalText: "More Info",
 
@@ -267,6 +268,7 @@ window.browzine = {
   articleExpressionOfConcernEnabled: true,
   articleExpressionOfConcernText: "Expression of Concern",
 
+  problematicJournalEnabled: true,
   problematicJournalText: "Problematic Journal",
 
   showFormatChoice: true,

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ var browzine = {
   articleExpressionOfConcernWording: "Expression of Concern",
   articleExpressionOfConcernText: "More Info",
 
+  problematicJournalWording: "Problematic Journal",
+  problematicJournalText: "More Info",
+
   iconColor: "#639add",
 
   showFormatChoice: true,
@@ -263,6 +266,8 @@ window.browzine = {
 
   articleExpressionOfConcernEnabled: true,
   articleExpressionOfConcernText: "Expression of Concern",
+
+  problematicJournalText: "Problematic Journal",
 
   showFormatChoice: true,
   showLinkResolverLink: true,

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -503,6 +503,17 @@ browzine.primo = (function() {
     return featureEnabled;
   };
 
+  function showProblematicJournal() {
+    var featureEnabled = false;
+    var config = browzine.problematicJournalEnabled;
+
+    if (typeof config === "undefined" || config === null || config === true) {
+      featureEnabled = true;
+    }
+
+    return featureEnabled;
+  }
+
   function enableLinkOptimizer() {
     var featureEnabled = false;
     var config = browzine.enableLinkOptimizer;
@@ -553,7 +564,7 @@ browzine.primo = (function() {
   }
 
   function showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl) {
-    return !!problematicJournalArticleNoticeUrl;
+    return !!problematicJournalArticleNoticeUrl && showProblematicJournal();
   }
 
   function directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
@@ -1008,7 +1019,7 @@ browzine.primo = (function() {
           libKeyLinkOptimizer.innerHTML += template;
         }
 
-        if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && !articleEocNoticeUrl && problematicJournalArticleNoticeUrl && isArticle(scope)) {
+        if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && !articleEocNoticeUrl && problematicJournalArticleNoticeUrl && isArticle(scope) && showProblematicJournal()) {
           var template = problematicJournalArticleNoticeLinkTemplate(problematicJournalArticleNoticeUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
@@ -1208,6 +1219,7 @@ browzine.primo = (function() {
     showPrintRecords: showPrintRecords,
     showRetractionWatch: showRetractionWatch,
     showExpressionOfConcern: showExpressionOfConcern,
+    showProblematicJournal: showProblematicJournal,
     showFormatChoice: showFormatChoice,
     showLinkResolverLink: showLinkResolverLink,
     enableLinkOptimizer: enableLinkOptimizer,

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -503,6 +503,17 @@ browzine.summon = (function() {
     return featureEnabled;
   };
 
+  function showProblematicJournal() {
+    var featureEnabled = false;
+    var config = browzine.problematicJournalEnabled;
+
+    if (typeof config === "undefined" || config === null || config === true) {
+      featureEnabled = true;
+    }
+
+    return featureEnabled;
+  }
+
   function showFormatChoice() {
     var featureEnabled = false;
     var config = browzine.showFormatChoice;
@@ -570,7 +581,7 @@ browzine.summon = (function() {
   }
 
   function showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl) {
-    return !!problematicJournalArticleNoticeUrl;
+    return !!problematicJournalArticleNoticeUrl && showProblematicJournal();
   }
 
   function directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
@@ -1013,7 +1024,7 @@ browzine.summon = (function() {
           libKeyLinkOptimizer.innerHTML += template;
         }
 
-        if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && !articleEocNoticeUrl && problematicJournalArticleNoticeUrl && isArticle(scope)) {
+        if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && !articleEocNoticeUrl && problematicJournalArticleNoticeUrl && isArticle(scope) && showProblematicJournal()) {
           var template = problematicJournalArticleNoticeLinkTemplate(problematicJournalArticleNoticeUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
@@ -1189,6 +1200,7 @@ browzine.summon = (function() {
     showPrintRecords: showPrintRecords,
     showRetractionWatch: showRetractionWatch,
     showExpressionOfConcern: showExpressionOfConcern,
+    showProblematicJournal: showProblematicJournal,
     showFormatChoice: showFormatChoice,
     showLinkResolverLink: showLinkResolverLink,
     enableLinkOptimizer: enableLinkOptimizer,

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -1229,7 +1229,7 @@ describe("BrowZine Primo Adapter >", function () {
       });
     });
 
-    describe("problematic journal notice with a custom problematic  and only an article link >", function () {
+    describe("problematic journal notice with a custom text label >", function () {
       beforeEach(function () {
         primo = browzine.primo;
 
@@ -1329,6 +1329,109 @@ describe("BrowZine Primo Adapter >", function () {
 
         expect(template.text().trim()).toContain("View Issue Contents");
         expect(template.text().trim()).toContain("Perhaps this is a Problematic Journal");
+      });
+    });
+
+    describe("problematic journal notice disabled >", function () {
+      beforeEach(function () {
+        primo = browzine.primo;
+
+        browzine.problematicJournalEnabled = false;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["10837159"],
+                      doi: ["10.1634/theoncologist.8-4-307"]
+                    }
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$parent.$ctrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "problematicJournalArticleNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic",
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function () {
+        delete browzine.problematicJournalEnabled;
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show problematic journal notices when there is only an article link", function () {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).not.toContain("Perhaps this is a Problematic Journal");
       });
     });
 

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -1229,6 +1229,109 @@ describe("BrowZine Primo Adapter >", function () {
       });
     });
 
+    describe("problematic journal notice with a custom problematic  and only an article link >", function () {
+      beforeEach(function () {
+        primo = browzine.primo;
+
+        browzine.problematicJournalText = "Perhaps this is a Problematic Journal";
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["10837159"],
+                      doi: ["10.1634/theoncologist.8-4-307"]
+                    }
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$parent.$ctrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "problematicJournalArticleNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic",
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function () {
+        delete browzine.problematicJournalText;
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show problematic journal notices when there is only an article link", function () {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).toContain("Perhaps this is a Problematic Journal");
+      });
+    });
+
     describe("retraction notice and no pdf link or article link >", function () {
       beforeEach(function () {
         primo = browzine.primo;

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -907,6 +907,96 @@ describe("BrowZine Summon Adapter >", function() {
       });
     });
 
+    describe("problematic journal notice with customized problematic journal wording and only an article link >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+
+        browzine.problematicJournalWording = 'This Might Be Problematic';
+        browzine.problematicJournalText = 'Even More Info';
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1634/theoncologist.8-4-307"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "problematicJournalArticleNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic"
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        delete browzine.problematicJournalWording;
+        delete browzine.problematicJournalText;
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show problematic journal article notices when there is only an article link", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View in Context Browse Journal");
+        expect(template.text().trim()).toContain("This Might Be Problematic Even More Info");
+      });
+    });
+
     describe("retraction notice and no pdf link or article link >", function() {
       beforeEach(function() {
         summon = browzine.summon;

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -997,6 +997,94 @@ describe("BrowZine Summon Adapter >", function() {
       });
     });
 
+    describe("problematic journal notice disabled >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+
+        browzine.problematicJournalEnabled = false;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1634/theoncologist.8-4-307"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "problematicJournalArticleNoticeUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307.problematic"
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        delete browzine.problematicJournalEnabled;
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show no problematic journal label when it is disabled", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View in Context Browse Journal");
+        expect(template.text().trim()).not.toContain("Problematic Journal More Info");
+      });
+    });
+
     describe("retraction notice and no pdf link or article link >", function() {
       beforeEach(function() {
         summon = browzine.summon;

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -2003,6 +2003,36 @@ describe("Primo Model >", function() {
     });
   });
 
+  describe("primo model showProblematicJournal method >", function() {
+    beforeEach(function() {
+      delete browzine.problematicJournalEnabled;
+    });
+
+    afterEach(function() {
+      delete browzine.problematicJournalEnabled;
+    });
+
+    it("should enable problematic journals when configuration property is undefined", function() {
+      delete browzine.problematicJournalEnabled;
+      expect(primo.showProblematicJournal()).toEqual(true);
+    });
+
+    it("should enable problematic journals when configuration property is null", function() {
+      browzine.problematicJournalEnabled = null;
+      expect(primo.showProblematicJournal()).toEqual(true);
+    });
+
+    it("should enable problematic journals when configuration property is true", function() {
+      browzine.problematicJournalEnabled = true;
+      expect(primo.showProblematicJournal()).toEqual(true);
+    });
+
+    it("should disable problematic journals when configuration property is false", function() {
+      browzine.problematicJournalEnabled = false;
+      expect(primo.showProblematicJournal()).toEqual(false);
+    });
+  });
+
   describe("primo model showFormatChoice method >", function() {
     beforeEach(function() {
       delete browzine.showFormatChoice;

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -1446,6 +1446,36 @@ describe("Summon Model >", function() {
     });
   });
 
+  describe("summon model showProblematicJournal method >", function() {
+    beforeEach(function() {
+      delete browzine.problematicJournalEnabled;
+    });
+
+    afterEach(function() {
+      delete browzine.problematicJournalEnabled;
+    });
+
+    it("should enable problematic journals when configuration property is undefined", function() {
+      delete browzine.problematicJournalEnabled;
+      expect(summon.showProblematicJournal()).toEqual(true);
+    });
+
+    it("should enable problematic journals when configuration property is null", function() {
+      browzine.problematicJournalEnabled = null;
+      expect(summon.showProblematicJournal()).toEqual(true);
+    });
+
+    it("should enable problematic journals when configuration property is true", function() {
+      browzine.problematicJournalEnabled = true;
+      expect(summon.showProblematicJournal()).toEqual(true);
+    });
+
+    it("should disable problematic journals when configuration property is false", function() {
+      browzine.problematicJournalEnabled = false;
+      expect(summon.showProblematicJournal()).toEqual(false);
+    });
+  });
+
   describe("summon model showFormatChoice method >", function() {
     beforeEach(function() {
       delete browzine.showFormatChoice;


### PR DESCRIPTION
## Summary - [BZ-9521](https://thirdiron.atlassian.net/browse/BZ-9521)

<!--Required section. The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Add `problematicJournalText` and `problematicJournalEnabled` to Primo and Summon, and `problematicJournalWording` to Summon

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

Allow configuration of turning on and off the Problematic Journals display, and allow custom text on the Problematic Journals UI elements.

The naming conventions match up with what we've done for other features: singular and with a "text" and "wording" alternate.


## Deploy Prerequisites

<!-- Things that must be completed before deployment can safely proceed. Delete any of the items below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Precautions

<!--Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Informational Notes

<!--Things that are not concerns that would hold up a deployment or shape how a deployment is executed, but may be useful to know about when preparing for a deployment or after a deployment is completed. Delete any of the notices below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None



[BZ-9521]: https://thirdiron.atlassian.net/browse/BZ-9521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ