### PR TITLE
Doc delivery fulfillment support - bz 9457

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ window.browzine = {
   problematicJournalEnabled: true,
   problematicJournalText: "Problematic Journal",
 
+  documentDeliveryFulfillmentText: "Request PDF",
+
   showFormatChoice: true,
   showLinkResolverLink: true,
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ var browzine = {
   problematicJournalWording: "Problematic Journal",
   problematicJournalText: "More Info",
 
+  documentDeliveryFulfillmentWording: "Request Now",
+  documentDeliveryFulfillmentText: "PDF",
+
   iconColor: "#639add",
 
   showFormatChoice: true,

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -300,6 +300,18 @@ browzine.primo = (function() {
     return problematicJournalArticleNoticeUrl;
   }
 
+  function getDocumentDeliveryFulfillmentUrl(scope, data) {
+    var documentDeliveryUrl = null;
+
+    if (isArticle(scope)) {
+      if (data && data.documentDeliveryFulfillmentUrl) {
+        documentDeliveryUrl = data.documentDeliveryFulfillmentUrl;
+      }
+    }
+    return documentDeliveryUrl;
+  };
+
+
   function isTrustedRepository(response) {
     var validation = false;
 
@@ -514,6 +526,17 @@ browzine.primo = (function() {
     return featureEnabled;
   }
 
+  function showDocumentDeliveryFulfillment() {
+    var featureEnabled = false;
+    var config = browzine.documentDeliveryFulfillmentEnabled;
+
+    if (typeof config === "undefined" || config === null || config === true) {
+      featureEnabled = true;
+    }
+
+    return featureEnabled;
+  }
+
   function enableLinkOptimizer() {
     var featureEnabled = false;
     var config = browzine.enableLinkOptimizer;
@@ -567,7 +590,11 @@ browzine.primo = (function() {
     return !!problematicJournalArticleNoticeUrl && showProblematicJournal();
   }
 
-  function directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
+  function showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl) {
+    return !!documentDeliveryFulfillmentUrl && showDocumentDeliveryFulfillment();
+  }
+
+  function directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl, documentDeliveryFulfillmentUrl) {
     var pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-pdf-download-icon.svg";
     var pdfIconWidth = "12";
     var pdfIconMarginRight = "4.5px";
@@ -591,6 +618,10 @@ browzine.primo = (function() {
       pdfIconWidth = "15";
       pdfIconMarginRight = "1.5px";
       articlePDFDownloadLinkText = browzine.problematicJournalText || "Problematic Journal";
+    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+      directToPDFUrl = documentDeliveryFulfillmentUrl;
+      // pdfIcon stays the same
+      articlePDFDownloadLinkText = browzine.documentDeliveryFulfillmentText || "Request PDF";
     }
 
     var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
@@ -610,7 +641,7 @@ browzine.primo = (function() {
     return template;
   };
 
-  function articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
+  function articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl, documentDeliveryFulfillmentUrl) {
     var linkIcon = "https://assets.thirdiron.com/images/integrations/browzine-article-link-icon.svg";
     var linkIconWidth = "12";
     var linkIconMarginRight = "4.5px";
@@ -634,6 +665,10 @@ browzine.primo = (function() {
       linkIconWidth = "15";
       linkIconMarginRight = "1.5px";
       articleLinkText = browzine.problematicJournalText || "Problematic Journal";
+    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+      articleLinkUrl = documentDeliveryFulfillmentUrl;
+      // link icon stays the same
+      articleLinkText = browzine.documentDeliveryFulfillmentText || "Request PDF";
     }
 
     var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
@@ -725,6 +760,30 @@ browzine.primo = (function() {
     return template;
   };
 
+  function documentDeliveryFulfillmentLinkTemplate(documentDeliveryFulfillmentUrl) {
+    var articleLinkUrl = documentDeliveryFulfillmentUrl;
+    var linkIcon = "https://assets.thirdiron.com/images/integrations/browzine-pdf-download-icon.svg";
+    var linkIconWidth = "15";
+    var linkIconMarginRight = "1.5px";
+    var articleLinkText = browzine.documentDeliveryFulfillmentText || "Request PDF";
+
+    var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
+                      "<a class='browzine-article-link' href='{articleLinkUrl}' target='_blank' onclick='browzine.primo.transition(event, this)'>" +
+                          "<img alt='BrowZine Article Link Icon' src='{linkIcon}' class='browzine-article-link-icon' style='margin-bottom: -3px; margin-right: {linkIconMarginRight};' aria-hidden='true' width='{linkIconWidth}' height='16'/> " +
+                          "<span class='browzine-article-link-text'>{articleLinkText}</span> " +
+                          "<md-icon md-svg-icon='primo-ui:open-in-new' class='md-primoExplore-theme' aria-hidden='true' style='height: 15px; width: 15px; min-height: 15px; min-width: 15px; margin-top: -2px;'><svg width='100%' height='100%' viewBox='0 0 24 24' y='504' xmlns='http://www.w3.org/2000/svg' fit='' preserveAspectRatio='xMidYMid meet' focusable='false'><path d='M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z'></path></svg></md-icon>" +
+                      "</a>" +
+                   "</div>";
+
+    template = template.replace(/{articleLinkUrl}/g, articleLinkUrl);
+    template = template.replace(/{articleLinkText}/g, articleLinkText);
+    template = template.replace(/{linkIcon}/g, linkIcon);
+    template = template.replace(/{linkIconWidth}/g, linkIconWidth);
+    template = template.replace(/{linkIconMarginRight}/g, linkIconMarginRight);
+
+    return template;
+  };
+
 
   function browzineWebLinkTemplate(scope, browzineWebLink) {
     var browzineWebLinkText = "";
@@ -753,7 +812,7 @@ browzine.primo = (function() {
     return template;
   };
 
-  function unpaywallArticlePDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
+  function unpaywallArticlePDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl, documentDeliveryFulfillmentUrl) {
     var pdfIcon = "https://assets.thirdiron.com/images/integrations/browzine-pdf-download-icon.svg";
     var pdfIconWidth = "12";
     var pdfIconMarginRight = "4.5px";
@@ -777,6 +836,10 @@ browzine.primo = (function() {
       pdfIconWidth = "15";
       pdfIconMarginRight = "1.5px";
       articlePDFDownloadLinkText = browzine.problematicJournalText || "Problematic Journal";
+    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+      directToPDFUrl = documentDeliveryFulfillmentUrl;
+      // pdfIcon stays the same
+      articlePDFDownloadLinkText = browzine.documentDeliveryFulfillmentText || "Request PDF";
     }
 
     var template = "<div class='browzine' style='line-height: 1.4em; margin-right: 4.5em;'>" +
@@ -992,6 +1055,7 @@ browzine.primo = (function() {
         var articleRetractionUrl = getArticleRetractionUrl(scope, data);
         var articleEocNoticeUrl = getArticleEOCNoticeUrl(scope, data);
         var problematicJournalArticleNoticeUrl = getProblematicJournalArticleNoticeUrl(scope, data);
+        var documentDeliveryFulfillmentUrl = getDocumentDeliveryFulfillmentUrl(scope, data);
 
         var element = getElement(scope);
 
@@ -1000,12 +1064,12 @@ browzine.primo = (function() {
         libKeyLinkOptimizer.style = "display: flex; justify-content: flex-start;";
 
         if (directToPDFUrl && isArticle(scope) && showDirectToPDFLink()) {
-          var template = directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl);
+          var template = directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl, documentDeliveryFulfillmentUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 
         if ((!directToPDFUrl || (showFormatChoice() && !articleRetractionUrl && !articleEocNoticeUrl && !problematicJournalArticleNoticeUrl)) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
-          var template = articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl);
+          var template = articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl, documentDeliveryFulfillmentUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 
@@ -1021,6 +1085,11 @@ browzine.primo = (function() {
 
         if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && !articleEocNoticeUrl && problematicJournalArticleNoticeUrl && isArticle(scope) && showProblematicJournal()) {
           var template = problematicJournalArticleNoticeLinkTemplate(problematicJournalArticleNoticeUrl);
+          libKeyLinkOptimizer.innerHTML += template;
+        }
+
+        if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && !articleEocNoticeUrl && !problematicJournalArticleNoticeUrl && isArticle(scope) && documentDeliveryFulfillmentUrl && showDocumentDeliveryFulfillment()) {
+          var template = documentDeliveryFulfillmentLinkTemplate(documentDeliveryFulfillmentUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 
@@ -1222,6 +1291,7 @@ browzine.primo = (function() {
     showProblematicJournal: showProblematicJournal,
     showFormatChoice: showFormatChoice,
     showLinkResolverLink: showLinkResolverLink,
+    showDocumentDeliveryFulfillment: showDocumentDeliveryFulfillment,
     enableLinkOptimizer: enableLinkOptimizer,
     transition: transition,
     directToPDFTemplate: directToPDFTemplate,

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -288,6 +288,18 @@ browzine.summon = (function() {
     return problematicJournalArticleNoticeUrl;
   }
 
+  function getDocumentDeliveryFulfillmentUrl(scope, data) {
+    var documentDeliveryFulfillmentUrl = null;
+
+    if (isArticle(scope)) {
+      if (data && data.documentDeliveryFulfillmentUrl) {
+        documentDeliveryFulfillmentUrl = data.documentDeliveryFulfillmentUrl;
+      }
+    }
+    return documentDeliveryFulfillmentUrl;
+  }
+
+
   function getPdfIconSvg() {
     var color = browzine.iconColor || "#639add";
 
@@ -514,6 +526,17 @@ browzine.summon = (function() {
     return featureEnabled;
   }
 
+  function showDocumentDeliveryFulfillment() {
+    var featureEnabled = false;
+    var config = browzine.documentDeliveryFulfillmentEnabled;
+
+    if (typeof config === "undefined" || config === null || config === true) {
+      featureEnabled = true;
+    }
+
+    return featureEnabled;
+  }
+
   function showFormatChoice() {
     var featureEnabled = false;
     var config = browzine.showFormatChoice;
@@ -584,7 +607,12 @@ browzine.summon = (function() {
     return !!problematicJournalArticleNoticeUrl && showProblematicJournal();
   }
 
-  function directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
+  function showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl) {
+    return !!documentDeliveryFulfillmentUrl && showDocumentDeliveryFulfillment();
+  }
+
+
+  function directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl, documentDeliveryFulfillmentUrl) {
     var pdfIcon = getPdfIconSvg();
     var pdfIconWidth = "13";
 
@@ -611,6 +639,11 @@ browzine.summon = (function() {
       pdfIcon = getRetractionWatchIconSvg();
       articlePDFDownloadWording = browzine.problematicJournalWording || "Problematic Journal";
       articlePDFDownloadLinkText = browzine.problematicJournalText || "More Info";
+    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+      directToPDFUrl = documentDeliveryFulfillmentUrl;
+      // pdfIcon can stay the same
+      articlePDFDownloadWording = browzine.documentDeliveryFulfillmentWording || "Request Now";
+      articlePDFDownloadLinkText = browzine.documentDeliveryFulfillmentText || "PDF";
     }
 
     var template = "<div class='browzine'>" +
@@ -627,7 +660,7 @@ browzine.summon = (function() {
     return template;
   };
 
-  function articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
+  function articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl, documentDeliveryFulfillmentUrl) {
     var paperIcon = getPaperIconSvg();
 
     var articleLinkTextWording = "View Now";
@@ -653,6 +686,11 @@ browzine.summon = (function() {
       pdfIcon = getRetractionWatchIconSvg();
       articleLinkTextWording = browzine.problematicJournalWording || "Problematic Journal";
       articleLinkText = browzine.problematicJournalText || "More Info";
+    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+      articleLinkUrl = documentDeliveryFulfillmentUrl;
+      pdfIcon = getRetractionWatchIconSvg();
+      articleLinkTextWording = browzine.documentDeliveryFulfillmentWording || "Request Now";
+      articleLinkText = browzine.documentDeliveryFulfillmentText || "PDF";
     }
 
     var template = "<div class='browzine'>" +
@@ -733,6 +771,26 @@ browzine.summon = (function() {
     return template;
   };
 
+  function documentDeliveryFulfillmentLinkTemplate(documentDeliveryFulfillmentUrl) {
+    var articleLinkUrl = documentDeliveryFulfillmentUrl;
+    var paperIcon = getPaperIconSvg();
+
+   var articleLinkTextWording = browzine.documentDeliveryFulfillmentWording || "Request Now";
+   var articleLinkText = browzine.documentDeliveryFulfillmentText || "PDF";
+
+    var template = "<div class='browzine'>" +
+      "<span class='contentType' style='margin-right: 4.5px;'>{articleLinkTextWording}</span>" +
+      "<a class='browzine-article-link summonBtn customPrimaryLink' href='{articleLinkUrl}' target='_blank' onclick='browzine.summon.transition(event, this)'>{paperIcon}<span style='margin-left: 0px;'>{articleLinkText}</span></a>" +
+    "</div>";
+
+    template = template.replace(/{articleLinkTextWording}/g, articleLinkTextWording);
+    template = template.replace(/{articleLinkUrl}/g, articleLinkUrl);
+    template = template.replace(/{articleLinkText}/g, articleLinkText);
+    template = template.replace(/{paperIcon}/g, paperIcon);
+
+    return template;
+  };
+
   function browzineWebLinkTemplate(scope, browzineWebLink) {
     var wording = "";
     var browzineWebLinkText = "";
@@ -770,7 +828,7 @@ browzine.summon = (function() {
     return template;
   };
 
-  function unpaywallArticlePDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
+  function unpaywallArticlePDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl, documentDeliveryFulfillmentUrl) {
     var pdfIcon = getPdfIconSvg();
     var pdfIconWidth = "13";
 
@@ -797,6 +855,11 @@ browzine.summon = (function() {
       pdfIcon = getRetractionWatchIconSvg();
       articlePDFDownloadWording = browzine.problematicJournalWording || "Problematic Journal";
       articlePDFDownloadLinkText = browzine.problematicJournalText || "More Info";
+    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+      directToPDFUrl = documentDeliveryFulfillmentUrl;
+      // pdfIcon stays the same
+      articlePDFDownloadWording = browzine.documentDeliveryFulfillmentWording || "Request PDF";
+      articlePDFDownloadLinkText = browzine.documentDeliveryFulfillmentText || "More Info";
     }
 
     var template = "<div class='browzine'>" +
@@ -836,7 +899,7 @@ browzine.summon = (function() {
     return template;
   };
 
-  function unpaywallManuscriptPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl) {
+  function unpaywallManuscriptPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl, documentDeliveryFulfillmentUrl) {
     var pdfIcon = getPdfIconSvg();
     var pdfIconWidth = "13";
 
@@ -863,6 +926,11 @@ browzine.summon = (function() {
       pdfIcon = getRetractionWatchIconSvg();
       articlePDFDownloadWording = browzine.problematicJournalWording || "Problematic Journal";
       articlePDFDownloadLinkText = browzine.problematicJournalText || "More Info";
+    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+      directToPDFUrl = documentDeliveryFulfillmentUrl;
+      // pdfIcon stays the same
+      articlePDFDownloadWording = browzine.documentDeliveryFulfillmentWording || "Request PDF";
+      articlePDFDownloadLinkText = browzine.documentDeliveryFulfillmentText || "More Info";
     }
 
     var template = "<div class='browzine'>" +
@@ -998,6 +1066,7 @@ browzine.summon = (function() {
         var articleRetractionUrl = getArticleRetractionUrl(scope, data);
         var articleEocNoticeUrl = getArticleEOCNoticeUrl(scope, data);
         var problematicJournalArticleNoticeUrl = getProblematicJournalArticleNoticeUrl(scope, data);
+        var documentDeliveryFulfillmentUrl = getDocumentDeliveryFulfillmentUrl(scope, data);
         var unpaywallUsable = getUnpaywallUsable(scope, data);
 
         var libKeyLinkOptimizer = document.createElement("div");
@@ -1005,12 +1074,12 @@ browzine.summon = (function() {
         libKeyLinkOptimizer.style = "display: flex; justify-content: flex-start;";
 
         if (directToPDFUrl && isArticle(scope) && showDirectToPDFLink()) {
-          var template = directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl);
+          var template = directToPDFTemplate(directToPDFUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl, documentDeliveryFulfillmentUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 
         if ((!directToPDFUrl || (showFormatChoice() && !articleRetractionUrl && !articleEocNoticeUrl)) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
-          var template = articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl);
+          var template = articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl, documentDeliveryFulfillmentUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }
 
@@ -1029,6 +1098,10 @@ browzine.summon = (function() {
           libKeyLinkOptimizer.innerHTML += template;
         }
 
+        if (!directToPDFUrl && !articleLinkUrl && !articleRetractionUrl && !articleEocNoticeUrl && !problematicJournalArticleNoticeUrl && documentDeliveryFulfillmentUrl && isArticle(scope) && showDocumentDeliveryFulfillment()) {
+          var template = documentDeliveryFulfillmentLinkTemplate(documentDeliveryFulfillmentUrl);
+          libKeyLinkOptimizer.innerHTML += template;
+        }
 
 
         if (libKeyLinkOptimizer.innerHTML) {
@@ -1111,6 +1184,7 @@ browzine.summon = (function() {
               var articleRetractionUrl = getArticleRetractionUrl(scope, data);
               var articleEocNoticeUrl = getArticleEOCNoticeUrl(scope, data);
               var problematicJournalArticleNoticeUrl = getProblematicJournalArticleNoticeUrl(scope, data);
+              // no need to check for unmediated document delivery here, because if it came from Unpaywall, it's Open Access
 
               var template;
               var pdfAvailable = false;
@@ -1203,6 +1277,7 @@ browzine.summon = (function() {
     showProblematicJournal: showProblematicJournal,
     showFormatChoice: showFormatChoice,
     showLinkResolverLink: showLinkResolverLink,
+    showDocumentDeliveryFulfillment: showDocumentDeliveryFulfillment,
     enableLinkOptimizer: enableLinkOptimizer,
     isFiltered: isFiltered,
     transition: transition,

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -678,17 +678,17 @@ browzine.summon = (function() {
       articleLinkText = browzine.articleRetractionWatchText || "More Info";
     } else if (showEocNoticeUI(articleEocNoticeUrl)) {
       articleLinkUrl = articleEocNoticeUrl;
-      pdfIcon = getRetractionWatchIconSvg();
+      paperIcon = getRetractionWatchIconSvg();
       articleLinkTextWording = browzine.articleExpressionOfConcernWording || "Expression of Concern";
       articleLinkText = browzine.articleExpressionOfConcernText || "More Info";
     } else if (showProblematicJournalArticleNoticeUI(problematicJournalArticleNoticeUrl)) {
       articleLinkUrl = problematicJournalArticleNoticeUrl;
-      pdfIcon = getRetractionWatchIconSvg();
+      paperIcon = getRetractionWatchIconSvg();
       articleLinkTextWording = browzine.problematicJournalWording || "Problematic Journal";
       articleLinkText = browzine.problematicJournalText || "More Info";
     } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
       articleLinkUrl = documentDeliveryFulfillmentUrl;
-      pdfIcon = getRetractionWatchIconSvg();
+      // paperIcon should stay the same
       articleLinkTextWording = browzine.documentDeliveryFulfillmentWording || "Request Now";
       articleLinkText = browzine.documentDeliveryFulfillmentText || "PDF";
     }

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -1435,6 +1435,244 @@ describe("BrowZine Primo Adapter >", function () {
       });
     });
 
+    describe("document delivery fulfillment on an article link >", function () {
+      beforeEach(function () {
+        primo = browzine.primo;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["10837159"],
+                      doi: ["10.1634/theoncologist.8-4-307"]
+                    }
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$parent.$ctrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "documentDeliveryFulfillmentUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572",
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function () {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show document delivery fulfillment", function () {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).toContain("Request PDF");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.svg");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-article-link-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-article-link-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function (done) {
+        requestAnimationFrame(function () {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function (coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/1083-7159.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when a document delivery fulfillment link is clicked", function () {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function () {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572", "_blank");
+      });
+    });
+
+
+    describe("document delivery fulfillment with custom label >", function () {
+      beforeEach(function () {
+        primo = browzine.primo;
+
+        browzine.documentDeliveryFulfillmentText = 'Get me that PDF'; // when I have "Request for the best", it intermittently fails!
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["10837159"],
+                      doi: ["10.1634/theoncologist.8-4-307"]
+                    }
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$parent.$ctrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "documentDeliveryFulfillmentUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572",
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function () {
+        delete browzine.documentDeliveryFulfillmentText;
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show document delivery fulfillment", function () {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).toContain("Get me that PDF");
+      });
+    });
+
+
     describe("retraction notice and no pdf link or article link >", function () {
       beforeEach(function () {
         primo = browzine.primo;

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -1181,7 +1181,7 @@ describe("BrowZine Summon Adapter >", function() {
         expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/1083-7159.png");
       });
 
-      it("should open a new window when a problematic journal article notice link is clicked", function() {
+      it("should open a new window when a document delivery fulfillment link is clicked", function() {
         spyOn(window, "open");
         documentSummary.find(".browzine .browzine-article-link").click();
         expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572", "_blank");

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -1268,6 +1268,8 @@ describe("BrowZine Summon Adapter >", function() {
       });
 
       afterEach(function() {
+        delete browzine.documentDeliveryFulfillmentWording;
+        delete browzine.documentDeliveryFulfillmentText;
         jasmine.Ajax.uninstall();
       });
 

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -1085,6 +1085,202 @@ describe("BrowZine Summon Adapter >", function() {
       });
     });
 
+    describe("document delivery fulfillment on an article link >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1634/theoncologist.8-4-307"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "documentDeliveryFulfillmentUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572",
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show document delivery fulfillment link", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View in Context Browse Journal");
+        expect(template.text().trim()).toContain("Request Now PDF");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+      });
+
+      it("should have an enhanced browzine journal cover", function() {
+        var coverImage = documentSummary.find(".coverImage img");
+        expect(coverImage).toBeDefined();
+        expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/1083-7159.png");
+      });
+
+      it("should open a new window when a problematic journal article notice link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572", "_blank");
+      });
+    });
+
+    describe("document delivery fulfillment with a custom label >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+
+        browzine.documentDeliveryFulfillmentWording = 'Request this!';
+        browzine.documentDeliveryFulfillmentText = 'Get me that PDF';
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1634/theoncologist.8-4-307"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "documentDeliveryFulfillmentUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572",
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show document delivery fulfillment link with custom labels", function() {
+        var template = documentSummary.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View in Context Browse Journal");
+        expect(template.text().trim()).toContain("Request this! Get me that PDF");
+      });
+    });
+
     describe("retraction notice and no pdf link or article link >", function() {
       beforeEach(function() {
         summon = browzine.summon;

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -2033,6 +2033,37 @@ describe("Primo Model >", function() {
     });
   });
 
+  describe("primo model showDocumentDeliveryFulfillment method >", function() {
+    beforeEach(function() {
+      delete browzine.documentDeliveryFulfillmentEnabled;
+    });
+
+    afterEach(function() {
+      delete browzine.documentDeliveryFulfillmentEnabled;
+    });
+
+    it("should enable problematic journals when configuration property is undefined", function() {
+      delete browzine.problematicJournalEnabled;
+      expect(primo.showProblematicJournal()).toEqual(true);
+    });
+
+    it("should enable problematic journals when configuration property is null", function() {
+      browzine.problematicJournalEnabled = null;
+      expect(primo.showProblematicJournal()).toEqual(true);
+    });
+
+    it("should enable problematic journals when configuration property is true", function() {
+      browzine.problematicJournalEnabled = true;
+      expect(primo.showProblematicJournal()).toEqual(true);
+    });
+
+    it("should disable problematic journals when configuration property is false", function() {
+      browzine.problematicJournalEnabled = false;
+      expect(primo.showProblematicJournal()).toEqual(false);
+    });
+  });
+
+
   describe("primo model showFormatChoice method >", function() {
     beforeEach(function() {
       delete browzine.showFormatChoice;

--- a/tests/unit/models/primo.js
+++ b/tests/unit/models/primo.js
@@ -2042,24 +2042,24 @@ describe("Primo Model >", function() {
       delete browzine.documentDeliveryFulfillmentEnabled;
     });
 
-    it("should enable problematic journals when configuration property is undefined", function() {
-      delete browzine.problematicJournalEnabled;
-      expect(primo.showProblematicJournal()).toEqual(true);
+    it("should enable document delivery fulfillment when configuration property is undefined", function() {
+      delete browzine.documentDeliveryFulfillmentEnabled;
+      expect(primo.showDocumentDeliveryFulfillment()).toEqual(true);
     });
 
-    it("should enable problematic journals when configuration property is null", function() {
-      browzine.problematicJournalEnabled = null;
-      expect(primo.showProblematicJournal()).toEqual(true);
+    it("should enable document delivery fulfillment when configuration property is null", function() {
+      browzine.documentDeliveryFulfillmentEnabled = null;
+      expect(primo.showDocumentDeliveryFulfillment()).toEqual(true);
     });
 
-    it("should enable problematic journals when configuration property is true", function() {
-      browzine.problematicJournalEnabled = true;
-      expect(primo.showProblematicJournal()).toEqual(true);
+    it("should enable document delivery fulfillment when configuration property is true", function() {
+      browzine.documentDeliveryFulfillmentEnabled = true;
+      expect(primo.showDocumentDeliveryFulfillment()).toEqual(true);
     });
 
-    it("should disable problematic journals when configuration property is false", function() {
-      browzine.problematicJournalEnabled = false;
-      expect(primo.showProblematicJournal()).toEqual(false);
+    it("should disable document delivery fulfillment when configuration property is false", function() {
+      browzine.documentDeliveryFulfillmentEnabled = false;
+      expect(primo.showDocumentDeliveryFulfillment()).toEqual(false);
     });
   });
 

--- a/tests/unit/models/summon.js
+++ b/tests/unit/models/summon.js
@@ -1476,6 +1476,36 @@ describe("Summon Model >", function() {
     });
   });
 
+  describe("summon model showDocumentDeliveryFulfillment method >", function() {
+    beforeEach(function() {
+      delete browzine.documentDeliveryFulfillmentEnabled;
+    });
+
+    afterEach(function() {
+      delete browzine.documentDeliveryFulfillmentEnabled;
+    });
+
+    it("should enable document delivery fulfillment when configuration property is undefined", function() {
+      delete browzine.documentDeliveryFulfillmentEnabled;
+      expect(summon.showDocumentDeliveryFulfillment()).toEqual(true);
+    });
+
+    it("should enable document delivery fulfillment when configuration property is null", function() {
+      browzine.documentDeliveryFulfillmentEnabled = null;
+      expect(summon.showDocumentDeliveryFulfillment()).toEqual(true);
+    });
+
+    it("should enable document delivery fulfillment when configuration property is true", function() {
+      browzine.documentDeliveryFulfillmentEnabled = true;
+      expect(summon.showDocumentDeliveryFulfillment()).toEqual(true);
+    });
+
+    it("should disable document delivery fulfillment when configuration property is false", function() {
+      browzine.documentDeliveryFulfillmentEnabled = false;
+      expect(summon.showDocumentDeliveryFulfillment()).toEqual(false);
+    });
+  });
+
   describe("summon model showFormatChoice method >", function() {
     beforeEach(function() {
       delete browzine.showFormatChoice;


### PR DESCRIPTION
## Summary - [BZ-9457](https://thirdiron.atlassian.net/browse/BZ-9457)

<!--Required section. The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

Adds support for document delivery fulfillment

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

When the public API has document delivery fulfillment available, Summon and Primo will now use that. 

Primo customization option: `documentDeliveryFulfillmentText`

Summon customization options: `documentDeliveryFulfillmentWording` and `documentDeliveryFulfillmentText`



## Deploy Prerequisites

<!-- Things that must be completed before deployment can safely proceed. Delete any of the items below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Precautions

<!--Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Informational Notes

<!--Things that are not concerns that would hold up a deployment or shape how a deployment is executed, but may be useful to know about when preparing for a deployment or after a deployment is completed. Delete any of the notices below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None



[BZ-9457]: https://thirdiron.atlassian.net/browse/BZ-9457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ