### PR TITLE
remove prefix config prop and fix Article Link logic

### DIFF
--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -436,14 +436,9 @@ browzine.primo = (function() {
   function showDirectToPDFLink() {
     var featureEnabled = false;
     var config = browzine.articlePDFDownloadLinkEnabled;
-    var prefixConfig = browzine.primoArticlePDFDownloadLinkEnabled;
 
     if (typeof config === "undefined" || config === null || config === true) {
       featureEnabled = true;
-    }
-
-    if (typeof prefixConfig !== "undefined" && prefixConfig !== null && prefixConfig === false) {
-      featureEnabled = false;
     }
 
     return featureEnabled;

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -1063,7 +1063,7 @@ browzine.primo = (function() {
           libKeyLinkOptimizer.innerHTML += template;
         }
 
-        if ((!directToPDFUrl || (showFormatChoice() && !articleRetractionUrl && !articleEocNoticeUrl && !problematicJournalArticleNoticeUrl)) && articleLinkUrl && isArticle(scope) && showDirectToPDFLink() && showArticleLink()) {
+        if ((!directToPDFUrl || (showFormatChoice() && !articleRetractionUrl && !articleEocNoticeUrl && !problematicJournalArticleNoticeUrl)) && articleLinkUrl && isArticle(scope) && showArticleLink()) {
           var template = articleLinkTemplate(articleLinkUrl, articleRetractionUrl, articleEocNoticeUrl, problematicJournalArticleNoticeUrl, documentDeliveryFulfillmentUrl);
           libKeyLinkOptimizer.innerHTML += template;
         }


### PR DESCRIPTION
## Summary - 

While walking through the current primo code, Karl and I came across some logic that didn't quite seem right. We were only showing an Article Link button if the show direct to PDF link config was also true. Checked with JohnS and verified that we don't need to check the direct to PDF config value when determining if we should display an article link button.


