### PR TITLE
Fix when to show doc delivery link for both Primo and Summon - bz 9959

### DIFF
--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -1106,7 +1106,7 @@ browzine.primo = (function() {
           element.append(template);
         }
 
-        if (browzineWebLink && browzineEnabled && isArticle(scope) && (directToPDFUrl || articleLinkUrl) && showArticleBrowZineWebLinkText()) {
+        if (browzineWebLink && browzineEnabled && isArticle(scope) && (directToPDFUrl || articleLinkUrl || documentDeliveryFulfillmentUrl) && showArticleBrowZineWebLinkText()) {
           var template = browzineWebLinkTemplate(scope, browzineWebLink);
           element.append(template);
         }

--- a/src/primo/browzine-primo-adapter.js
+++ b/src/primo/browzine-primo-adapter.js
@@ -613,7 +613,7 @@ browzine.primo = (function() {
       pdfIconWidth = "15";
       pdfIconMarginRight = "1.5px";
       articlePDFDownloadLinkText = browzine.problematicJournalText || "Problematic Journal";
-    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+    } else if (!directToPDFUrl && showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
       directToPDFUrl = documentDeliveryFulfillmentUrl;
       // pdfIcon stays the same
       articlePDFDownloadLinkText = browzine.documentDeliveryFulfillmentText || "Request PDF";
@@ -660,7 +660,7 @@ browzine.primo = (function() {
       linkIconWidth = "15";
       linkIconMarginRight = "1.5px";
       articleLinkText = browzine.problematicJournalText || "Problematic Journal";
-    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+    } else if (!articleLinkUrl && showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
       articleLinkUrl = documentDeliveryFulfillmentUrl;
       // link icon stays the same
       articleLinkText = browzine.documentDeliveryFulfillmentText || "Request PDF";
@@ -831,7 +831,7 @@ browzine.primo = (function() {
       pdfIconWidth = "15";
       pdfIconMarginRight = "1.5px";
       articlePDFDownloadLinkText = browzine.problematicJournalText || "Problematic Journal";
-    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+    } else if (!directToPDFUrl && showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
       directToPDFUrl = documentDeliveryFulfillmentUrl;
       // pdfIcon stays the same
       articlePDFDownloadLinkText = browzine.documentDeliveryFulfillmentText || "Request PDF";

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -639,7 +639,7 @@ browzine.summon = (function() {
       pdfIcon = getRetractionWatchIconSvg();
       articlePDFDownloadWording = browzine.problematicJournalWording || "Problematic Journal";
       articlePDFDownloadLinkText = browzine.problematicJournalText || "More Info";
-    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+    } else if (!directToPDFUrl && showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
       directToPDFUrl = documentDeliveryFulfillmentUrl;
       // pdfIcon can stay the same
       articlePDFDownloadWording = browzine.documentDeliveryFulfillmentWording || "Request Now";
@@ -686,7 +686,7 @@ browzine.summon = (function() {
       paperIcon = getRetractionWatchIconSvg();
       articleLinkTextWording = browzine.problematicJournalWording || "Problematic Journal";
       articleLinkText = browzine.problematicJournalText || "More Info";
-    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+    } else if (!articleLinkUrl && showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
       articleLinkUrl = documentDeliveryFulfillmentUrl;
       // paperIcon should stay the same
       articleLinkTextWording = browzine.documentDeliveryFulfillmentWording || "Request Now";
@@ -855,7 +855,7 @@ browzine.summon = (function() {
       pdfIcon = getRetractionWatchIconSvg();
       articlePDFDownloadWording = browzine.problematicJournalWording || "Problematic Journal";
       articlePDFDownloadLinkText = browzine.problematicJournalText || "More Info";
-    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+    } else if (!directToPDFUrl && showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
       directToPDFUrl = documentDeliveryFulfillmentUrl;
       // pdfIcon stays the same
       articlePDFDownloadWording = browzine.documentDeliveryFulfillmentWording || "Request PDF";
@@ -926,7 +926,7 @@ browzine.summon = (function() {
       pdfIcon = getRetractionWatchIconSvg();
       articlePDFDownloadWording = browzine.problematicJournalWording || "Problematic Journal";
       articlePDFDownloadLinkText = browzine.problematicJournalText || "More Info";
-    } else if (showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
+    } else if (!directToPDFUrl && showDocumentDeliveryFulfillmentUI(documentDeliveryFulfillmentUrl)) {
       directToPDFUrl = documentDeliveryFulfillmentUrl;
       // pdfIcon stays the same
       articlePDFDownloadWording = browzine.documentDeliveryFulfillmentWording || "Request PDF";

--- a/src/summon/browzine-summon-adapter.js
+++ b/src/summon/browzine-summon-adapter.js
@@ -1119,7 +1119,7 @@ browzine.summon = (function() {
           $(documentSummary).find(".docFooter .row:eq(0)").append(template);
         }
 
-        if (browzineWebLink && browzineEnabled && isArticle(scope) && (directToPDFUrl || articleLinkUrl) && showArticleBrowZineWebLinkText()) {
+        if (browzineWebLink && browzineEnabled && isArticle(scope) && (directToPDFUrl || articleLinkUrl || documentDeliveryFulfillmentUrl) && showArticleBrowZineWebLinkText()) {
           var template = browzineWebLinkTemplate(scope, browzineWebLink);
           $(documentSummary).find(".docFooter .row:eq(0)").append(template);
         }

--- a/tests/acceptance/browzine-primo-adapter-test.js
+++ b/tests/acceptance/browzine-primo-adapter-test.js
@@ -1435,7 +1435,140 @@ describe("BrowZine Primo Adapter >", function () {
       });
     });
 
-    describe("document delivery fulfillment on an article link >", function () {
+    describe("article has a document delivery fulfillment link and neither an article link nor a direct-to-PDF link >", function () {
+      beforeEach(function () {
+        primo = browzine.primo;
+
+        searchResult = $("<div class='list-item-wrapper'><prm-brief-result-container><div class='result-item-image'><prm-search-result-thumbnail-container><img class='main-img fan-img-1' src=''/><img class='main-img fan-img-2' src=''/><img class='main-img fan-img-3' src=''/></prm-search-result-thumbnail-container></div><div class='result-item-text'><prm-search-result-availability-line><div class='layout-align-start-start'></div></prm-search-result-availability-line></div></prm-brief-result-container></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope = {
+            $parent: {
+              $ctrl: {
+                result: {
+                  pnx: {
+                    display: {
+                      type: ["article"]
+                    },
+
+                    addata: {
+                      issn: ["10837159"],
+                      doi: ["10.1634/theoncologist.8-4-307"]
+                    }
+                  }
+                }
+              }
+            }
+          };
+
+          searchResult = $compile(searchResult)($scope);
+        });
+
+        $scope.$parent.$ctrl.$element = searchResult;
+
+        jasmine.Ajax.install();
+
+        primo.searchResult($scope);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "documentDeliveryFulfillmentUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572",
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function () {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show document delivery fulfillment", function () {
+        var template = searchResult.find(".browzine");
+
+        expect(template).toBeDefined();
+
+        expect(template.text().trim()).toContain("View Issue Contents");
+        expect(template.text().trim()).toContain("Request PDF");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.svg");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+        expect(template.find("img.browzine-article-link-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-pdf-download-icon.svg");
+      });
+
+      it("should have an enhanced browzine journal cover", function (done) {
+        requestAnimationFrame(function () {
+          var coverImages = searchResult.find("prm-search-result-thumbnail-container img");
+          expect(coverImages).toBeDefined();
+
+          Array.prototype.forEach.call(coverImages, function (coverImage) {
+            expect(coverImage.src).toEqual("https://assets.thirdiron.com/images/covers/1083-7159.png");
+          });
+
+          done();
+        });
+      });
+
+      it("should open a new window when a document delivery fulfillment link is clicked", function () {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function () {
+        spyOn(window, "open");
+        searchResult.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572", "_blank");
+      });
+    });
+
+    describe("article has both a document delivery fulfillment link and an article link >", function () {
       beforeEach(function () {
         primo = browzine.primo;
 
@@ -1525,19 +1658,19 @@ describe("BrowZine Primo Adapter >", function () {
         jasmine.Ajax.uninstall();
       });
 
-      it("should show document delivery fulfillment", function () {
+      it("should show article link", function () {
         var template = searchResult.find(".browzine");
 
         expect(template).toBeDefined();
 
         expect(template.text().trim()).toContain("View Issue Contents");
-        expect(template.text().trim()).toContain("Request PDF");
+        expect(template.text().trim()).toContain("Read Article");
 
         expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572");
         expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
         expect(template.find("img.browzine-book-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-open-book-icon.svg");
 
-        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572");
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location");
         expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
         expect(template.find("img.browzine-article-link-icon").attr("src")).toEqual("https://assets.thirdiron.com/images/integrations/browzine-article-link-icon.svg");
       });
@@ -1558,7 +1691,7 @@ describe("BrowZine Primo Adapter >", function () {
       it("should open a new window when a document delivery fulfillment link is clicked", function () {
         spyOn(window, "open");
         searchResult.find(".browzine .browzine-article-link").click();
-        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572", "_blank");
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location", "_blank");
       });
 
       it("should open a new window when a browzine web link is clicked", function () {
@@ -1569,7 +1702,7 @@ describe("BrowZine Primo Adapter >", function () {
     });
 
 
-    describe("document delivery fulfillment with custom label >", function () {
+    describe("article has only a document delivery fulfillment link, but has a custom document delivery fulfillment label >", function () {
       beforeEach(function () {
         primo = browzine.primo;
 
@@ -1623,7 +1756,7 @@ describe("BrowZine Primo Adapter >", function () {
               "doi": "10.1634/theoncologist.8-4-307",
               "openAccess": false,
               "fullTextFile": "",
-              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location",
+              "contentLocation": "",
               "availableThroughBrowzine": true,
               "startPage": "2382",
               "endPage": "2393",

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -1085,7 +1085,118 @@ describe("BrowZine Summon Adapter >", function() {
       });
     });
 
-    describe("document delivery fulfillment on an article link >", function() {
+    describe("article has a document delivery fulfillment link and neither an article link nor a direct-to-PDF link >", function() {
+      beforeEach(function() {
+        summon = browzine.summon;
+
+        documentSummary = $("<div class='documentSummary' document-summary><div class='coverImage'><img src=''/></div><div class='docFooter'><div class='row'></div></div></div>");
+
+        inject(function ($compile, $rootScope) {
+          $scope = $rootScope.$new();
+
+          $scope.document = {
+            content_type: "Journal Article",
+            dois: ["10.1634/theoncologist.8-4-307"]
+          };
+
+          documentSummary = $compile(documentSummary)($scope);
+        });
+
+        jasmine.Ajax.install();
+
+        summon.adapter(documentSummary);
+
+        var request = jasmine.Ajax.requests.mostRecent();
+
+        request.respondWith({
+          status: 200,
+          contentType: "application/json",
+          response: JSON.stringify({
+            "data": {
+              "id": 43816537,
+              "type": "articles",
+              "title": "The HER-2/ neu Gene and Protein in Breast Cancer 2003: Biomarker and Target of Therapy",
+              "date": "2003-08-01",
+              "authors": "Ross, Jeffrey S.; Fletcher, Jonathan A.; Linette, Gerald P.; Stec, James; Clark, Edward; Ayers, Mark; Symmans, W. Fraser; Pusztai, Lajos; Bloom, Kenneth J.",
+              "inPress": false,
+              "doi": "10.1634/theoncologist.8-4-307",
+              "openAccess": false,
+              "fullTextFile": "",
+              "contentLocation": "",
+              "availableThroughBrowzine": true,
+              "startPage": "2382",
+              "endPage": "2393",
+              "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572",
+              "relationships": {
+                "journal": {
+                  "data": {
+                    "type": "journals",
+                    "id": 31343
+                  }
+                }
+              },
+              "documentDeliveryFulfillmentUrl": "https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572",
+            },
+            "included": [
+              {
+                "id": 31343,
+                "type": "journals",
+                "title": "The Oncologist",
+                "issn": "10837159",
+                "sjrValue": 1.859,
+                "coverImageUrl": "https://assets.thirdiron.com/images/covers/1083-7159.png",
+                "browzineEnabled": true,
+                "browzineWebLink": "https://develop.browzine.com/libraries/XXXX/journals/31343?utm_source=api_572"
+              },
+            ]
+          })
+        });
+
+        expect(request.url).toMatch(/articles\/doi\/10.1634%2Ftheoncologist.8-4-307/);
+        expect(request.method).toBe('GET');
+      });
+
+      afterEach(function() {
+        jasmine.Ajax.uninstall();
+      });
+
+      it("should show document delivery fulfillment link", function() {
+        console.log("documentSummary", documentSummary);
+        var template = documentSummary.find(".browzine");
+
+        console.log(template.text().trim());
+        expect(template).toBeDefined();
+
+        // expect(template.text().trim()).toContain("View in Context Browse Journal");
+        expect(template.text().trim()).toContain("Request Now PDF");
+
+        expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572");
+        expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
+
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572");
+        expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
+      });
+
+      it("should have an enhanced browzine journal cover", function() {
+        var coverImage = documentSummary.find(".coverImage img");
+        expect(coverImage).toBeDefined();
+        expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/1083-7159.png");
+      });
+
+      it("should open a new window when a document delivery fulfillment link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-article-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572", "_blank");
+      });
+
+      it("should open a new window when a browzine web link is clicked", function() {
+        spyOn(window, "open");
+        documentSummary.find(".browzine .browzine-web-link").click();
+        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572", "_blank");
+      });
+    });
+
+    describe("article has both a document delivery fulfillment link and an article link >", function() {
       beforeEach(function() {
         summon = browzine.summon;
 
@@ -1160,18 +1271,18 @@ describe("BrowZine Summon Adapter >", function() {
         jasmine.Ajax.uninstall();
       });
 
-      it("should show document delivery fulfillment link", function() {
+      it("should show article link", function() {
         var template = documentSummary.find(".browzine");
 
         expect(template).toBeDefined();
 
         expect(template.text().trim()).toContain("View in Context Browse Journal");
-        expect(template.text().trim()).toContain("Request Now PDF");
+        expect(template.text().trim()).toContain("View Now Article Page");
 
         expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572");
         expect(template.find("a.browzine-web-link").attr("target")).toEqual("_blank");
 
-        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572");
+        expect(template.find("a.browzine-article-link").attr("href")).toEqual("https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location");
         expect(template.find("a.browzine-article-link").attr("target")).toEqual("_blank");
       });
 
@@ -1180,21 +1291,9 @@ describe("BrowZine Summon Adapter >", function() {
         expect(coverImage).toBeDefined();
         expect(coverImage.attr("src")).toEqual("https://assets.thirdiron.com/images/covers/1083-7159.png");
       });
-
-      it("should open a new window when a document delivery fulfillment link is clicked", function() {
-        spyOn(window, "open");
-        documentSummary.find(".browzine .browzine-article-link").click();
-        expect(window.open).toHaveBeenCalledWith("https://develop.libkey.io/libraries/XXXX/10.1634/theoncologist.8-4-307/document-delivery-fulfillment?utm_source=api_572", "_blank");
-      });
-
-      it("should open a new window when a browzine web link is clicked", function() {
-        spyOn(window, "open");
-        documentSummary.find(".browzine .browzine-web-link").click();
-        expect(window.open).toHaveBeenCalledWith("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572", "_blank");
-      });
     });
 
-    describe("document delivery fulfillment with a custom label >", function() {
+    describe("article has only a document delivery fulfillment link, but has a custom document delivery fulfillment label >", function() {
       beforeEach(function() {
         summon = browzine.summon;
 
@@ -1233,7 +1332,7 @@ describe("BrowZine Summon Adapter >", function() {
               "doi": "10.1634/theoncologist.8-4-307",
               "openAccess": false,
               "fullTextFile": "",
-              "contentLocation": "https://develop.libkey.io/libraries/XXXX/articles/43816537/content-location",
+              "contentLocation": "",
               "availableThroughBrowzine": true,
               "startPage": "2382",
               "endPage": "2393",

--- a/tests/acceptance/browzine-summon-adapter-test.js
+++ b/tests/acceptance/browzine-summon-adapter-test.js
@@ -1161,13 +1161,10 @@ describe("BrowZine Summon Adapter >", function() {
       });
 
       it("should show document delivery fulfillment link", function() {
-        console.log("documentSummary", documentSummary);
         var template = documentSummary.find(".browzine");
-
-        console.log(template.text().trim());
         expect(template).toBeDefined();
 
-        // expect(template.text().trim()).toContain("View in Context Browse Journal");
+        expect(template.text().trim()).toContain("View in Context Browse Journal");
         expect(template.text().trim()).toContain("Request Now PDF");
 
         expect(template.find("a.browzine-web-link").attr("href")).toEqual("https://develop.browzine.com/libraries/XXXX/journals/31343/issues/5876785?showArticleInContext=doi:10.1634%2Ftheoncologist.8-4-307&utm_source=api_572");


### PR DESCRIPTION
## Summary - [BZ-9959](https://thirdiron.atlassian.net/browse/BZ-9959)

<!--Required section. The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

We should only show the Doc Delivery link if there is no valid article link or direct-to-PDF link.

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

When I first made #145 , I thought the public API only put the document delivery fulfillment URL into the API call when that was the only thing that could be used.

After talking with JohnM today, I determined I was wrong! It will show up even if you can access the article, because it's a perfectly valid use case that some folks may want to prefer doc delivery to other URLs in the system.  That's why we show both direct-to-PDF URLs and doc delivery URLs in the same public API response.

@johnmuth , since you haven't reviewed this repo much before, I'd just ask that you check the test describes and its to see if those make sense to you.  If so, then I think the behavior should match what the test description says.


## Deploy Prerequisites

<!-- Things that must be completed before deployment can safely proceed. Delete any of the items below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Precautions

<!--Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Informational Notes

<!--Things that are not concerns that would hold up a deployment or shape how a deployment is executed, but may be useful to know about when preparing for a deployment or after a deployment is completed. Delete any of the notices below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None



[BZ-9959]: https://thirdiron.atlassian.net/browse/BZ-9959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ