### PR TITLE
BZ-9932-Fix EJP Journal Images on wrong Element

### DIFF
--- a/src/360-core/browzine-360-core-adapter.js
+++ b/src/360-core/browzine-360-core-adapter.js
@@ -56,7 +56,7 @@ browzine.serSol360Core = (function() {
   };
 
   function getTarget(index) {
-    var elements = $(".results-identifier").closest(".results-title-row");
+    var elements = $(".results-title-row");
 
     if (index >= elements.length) {
       var target = undefined;


### PR DESCRIPTION
## Summary - [BZ-9932](https://thirdiron.atlassian.net/browse/BZ-9932)

<!--Required section. The high level goal of the desired outcome of this PR. This will be included in the auto-generated release notes for a prod deployment.-->

A customer reported that sometimes the journal image for a journal was being incorrectly attached to the wrong journal. 

## Description

<!-- Optional: For going into further detail on the change. Screenshots, gifs, review guidance, etc-->

While digging into this, my first thought was that something had changed with Syndetics, another service used by libraries to get journal images. But the deeper I dug the more the issues seemed to be off by one. So I looked at how we were finding our targets and that's when I discovered the problem. A few months ago while investigating BZ-9424 I made a change to our target to be based on index instead of an issn, since that was causing an issue with how our view journal in Browzine link was being attached. 

At the time, there wasn't an example of a listing without an identifier, and I wasn't aware that there could be options without an identifier, so I didn't take that into account, which is what caused this problem. In the example library given, one of the listings does not have an identifier, so therefore we skip it, but the indices don't get adjusted and therefore was causing an off by one issue (more if there are more listings without an identifier).

The fix is to just not only consider results with identifiers, our "shouldEnhance" function will deal with that. 

## Deploy Prerequisites

<!-- Things that must be completed before deployment can safely proceed. Delete any of the items below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Precautions

<!--Potential things to look out for during the deployment process. Delete any of the hazards below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None

## Deploy Informational Notes

<!--Things that are not concerns that would hold up a deployment or shape how a deployment is executed, but may be useful to know about when preparing for a deployment or after a deployment is completed. Delete any of the notices below that do not apply to this PR. Feel free to go into further detail on any of the points you decide to keep.-->

- None



[BZ-9932]: https://thirdiron.atlassian.net/browse/BZ-9932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ